### PR TITLE
Mark vLMM

### DIFF
--- a/MarkvLLM_demo.py
+++ b/MarkvLLM_demo.py
@@ -1,0 +1,112 @@
+import os.path
+import numpy as np
+
+from visualize.color_scheme import ColorSchemeForDiscreteVisualization
+from visualize.font_settings import FontSettings
+from visualize.legend_settings import DiscreteLegendSettings
+from visualize.page_layout_settings import PageLayoutSettings
+from visualize.visualizer import DiscreteVisualizer
+from vllm import LLM, SamplingParams
+
+import gc
+import sys
+import json
+import torch
+from watermark.auto_watermark import AutoWatermarkForVLLM
+from utils.transformers_config import TransformersConfig
+from transformers import AutoModelForCausalLM, AutoTokenizer, AutoConfig
+
+# Clean gpu memory
+assert torch.cuda.is_available()
+gc.collect()
+torch.cuda.empty_cache()
+with torch.no_grad():
+    torch.cuda.empty_cache()
+
+# Load data
+with open('dataset/c4/processed_c4.json', 'r') as f:
+    lines = f.readlines()
+    lines = [json.loads(line) for line in lines]
+
+
+def main(algorithm_name, model_path):
+    model = LLM(
+        model=model_path, trust_remote_code=True,
+        max_model_len=256,
+        gpu_memory_utilization=0.9,
+        enforce_eager=False,
+        dtype="auto",
+        disable_custom_all_reduce=False,
+        disable_log_stats=False,
+        swap_space=32,
+        seed=42
+    )
+    config = AutoConfig.from_pretrained(model_path)
+    transformers_config = TransformersConfig(
+        model=AutoModelForCausalLM.from_pretrained(model_path),
+        tokenizer=AutoTokenizer.from_pretrained(model_path),
+        vocab_size=config.vocab_size,
+        device="cuda",
+        max_new_tokens=256,
+        max_length=256,
+        do_sample=True,
+        no_repeat_ngram_size=4
+    )
+    watermark = AutoWatermarkForVLLM(algorithm_name=algorithm_name, algorithm_config=f'config/{algorithm_name}.json', transformers_config=transformers_config)
+    visualizer = DiscreteVisualizer(color_scheme=ColorSchemeForDiscreteVisualization(),
+                                    font_settings=FontSettings(),
+                                    page_layout_settings=PageLayoutSettings(),
+                                    legend_settings=DiscreteLegendSettings())
+
+    prompts = [line['prompt'] for line in lines]
+    references = [line['natural_text'] for line in lines]
+
+    # without watermark
+    outputs = model.generate(
+        prompts=prompts,
+        sampling_params=SamplingParams(
+            n=1, temperature=1.0, seed=42,
+            max_tokens=256, min_tokens=16,
+            logits_processors=[]
+        ),
+        use_tqdm=True,
+    )
+    nowatermark_text = [output.outputs[0].text for output in outputs]
+    nowatermark_ppl = np.mean([-output.outputs[0].cumulative_logprob/len(output.outputs[0].token_ids) for output in outputs])
+    nowatermark_detect_results = np.mean([r['is_watermarked'] for r in watermark.detect_watermark(nowatermark_text)])
+    print(f"nowatermark_ppl: {nowatermark_ppl:.3f}")
+    print(f"nowatermark_detect_results: {nowatermark_detect_results:.3f}")
+
+    # with watermark
+    outputs = model.generate(
+        prompts=prompts,
+        sampling_params=SamplingParams(
+            n=1, temperature=1.0, seed=42,
+            max_tokens=256, min_tokens=16,
+            logits_processors=[watermark]
+        ),
+        use_tqdm=True,
+    )
+    watermark_text = [output.outputs[0].text for output in outputs]
+    watermark_ppl = np.mean([-output.outputs[0].cumulative_logprob/len(output.outputs[0].token_ids) for output in outputs])
+    watermark_detect_results = np.mean([r['is_watermarked'] for r in watermark.detect_watermark(watermark_text)])
+    print(f"watermark_ppl: {watermark_ppl:.3f}")
+    print(f"watermark_detect_results: {watermark_detect_results:.3f}")
+
+    # visualize
+    nowatermarked_img = visualizer.visualize(
+        data=watermark.get_data_for_visualization(text=nowatermark_text[0]),
+        show_text=True, visualize_weight=True, display_legend=True
+    )
+    nowatermarked_img.save(os.path.join(model_path, f"{algorithm_name}-nowatermark-vllm.png"))
+    watermarked_img = visualizer.visualize(
+        data=watermark.get_data_for_visualization(text=watermark_text[0]),
+        show_text=True, visualize_weight=True, display_legend=True
+    )
+    watermarked_img.save(os.path.join(model_path, f"{algorithm_name}-watermark-vllm.png"))
+
+
+if __name__ == "__main__":
+    model_path = sys.argv[-2] # "meta-llama/Meta-Llama-3-8B-Instruct"
+    method = sys.argv[-1] # "UPV" "KGW" "Unigram"
+    main(model_path=model_path, algorithm_name=method)

--- a/MarkvLLM_demo.py
+++ b/MarkvLLM_demo.py
@@ -110,3 +110,17 @@ if __name__ == "__main__":
     model_path = sys.argv[-2] # "meta-llama/Meta-Llama-3-8B-Instruct"
     method = sys.argv[-1] # "UPV" "KGW" "Unigram"
     main(model_path=model_path, algorithm_name=method)
+    """
+    --------------------------------------------------------------
+    llama3-8b-instruct (vLLM)
+                           KGW               UPV           Unigram
+    PPL         1.191 -> 1.346    1.191 -> 0.926    1.191 -> 1.344
+    detect      0.001 -> 0.929    0.001 -> 0.430    0.001 -> 0.508
+    time (h)      0.19 -> 0.52      0.18 -> 2.02      0.18 -> 0.45
+    --------------------------------------------------------------
+    llama3-8b-instruct (huggingface)
+                           KGW               UPV           Unigram
+    detect      0.001 -> 0.934    0.001 -> 0.358    0.001 -> 0.505
+    time (h)    20.00 -> 20.75    19.50 -> 21.50    20.50 -> 20.50
+    --------------------------------------------------------------
+    """

--- a/watermark/auto_watermark.py
+++ b/watermark/auto_watermark.py
@@ -19,10 +19,9 @@
 #              with the [`AutoWatermark.load`] class method.
 # =========================================================================
 
+import torch
 import importlib
 from typing import List
-
-import torch
 
 WATERMARK_MAPPING_NAMES={
     'KGW': 'watermark.kgw.KGW',

--- a/watermark/upv/upv.py
+++ b/watermark/upv/upv.py
@@ -106,7 +106,7 @@ class UPVUtils:
     
     def int_to_bin_list(self, n: int, length=8) -> list[int]:
         """Convert an integer to a binary list of specified length."""
-        bin_str = format(n, 'b').zfill(length)
+        bin_str = format(n, 'b')[:length].zfill(length)
         return [int(b) for b in bin_str]
     
     def _select_candidates(self, scores: torch.Tensor) -> torch.Tensor:

--- a/watermark/upv/upv.py
+++ b/watermark/upv/upv.py
@@ -80,8 +80,8 @@ class UPVUtils:
                 config (UPVConfig): Configuration for the UPV algorithm.
         """
         self.config = config
-        self.generator_model = self._get_generator_model(self.config.bit_number, self.config.prefix_length + 1)
-        self.detector_model = self._get_detector_model(self.config.bit_number)
+        self.generator_model = self._get_generator_model(self.config.bit_number, self.config.prefix_length + 1).to(self.config.device)
+        self.detector_model = self._get_detector_model(self.config.bit_number).to(self.config.device)
         self.cache = {}
         self.top_k = self.config.gen_kwargs.get('top_k', self.config.default_top_k)
         self.num_beams = self.config.gen_kwargs.get('num_beams', None)  
@@ -100,8 +100,9 @@ class UPVUtils:
 
     def _get_predictions_from_generator(self, input_x: torch.Tensor) -> bool:
         """Get predictions from the generator model."""
-        output = self.generator_model(input_x)  
-        output = (output > 0.5).bool().item()
+        with torch.no_grad():
+            output = self.generator_model(input_x)
+            output = (output > 0.5).bool().item()
         return output
     
     def int_to_bin_list(self, n: int, length=8) -> list[int]:
@@ -129,12 +130,12 @@ class UPVUtils:
             # Now safely concatenate lists
             pair = input_ids_list[-self.config.prefix_length:] + [v.item()] if self.config.prefix_length > 0 else [v.item()]
             merged_tuple = tuple(pair)
-            bin_list = [self.int_to_bin_list(num, self.config.bit_number) for num in pair]
 
             if merged_tuple in self.cache:
                 result = self.cache[merged_tuple]
             else:
-                result = self._get_predictions_from_generator(torch.FloatTensor(bin_list).unsqueeze(0))
+                bin_list = [self.int_to_bin_list(num, self.config.bit_number) for num in pair]
+                result = self._get_predictions_from_generator(torch.tensor(bin_list, device=self.config.device).float().unsqueeze(0))
                 self.cache[merged_tuple] = result
             if result:
                 greenlist_ids.append(int(v))
@@ -155,7 +156,7 @@ class UPVUtils:
         if merged_tuple in self.cache:
             result = self.cache[merged_tuple]
         else:
-            result = self._get_predictions_from_generator(torch.FloatTensor(bin_list).unsqueeze(0))
+            result = self._get_predictions_from_generator(torch.tensor(bin_list, device=self.config.device).float().unsqueeze(0))
             self.cache[merged_tuple] = result
 
         return result
@@ -271,7 +272,7 @@ class UPV(BaseWatermark):
         """ Detect watermark using the network mode. """
         # Convert input IDs to binary sequence
         inputs_bin = [self.utils.int_to_bin_list(token_id, self.config.bit_number) for token_id in encoded_text]
-        inputs_bin = torch.tensor(inputs_bin)
+        inputs_bin = torch.tensor(inputs_bin, device=self.config.device)
 
         # Run the model on the input binary sequence
         outputs = self.utils.detector_model(inputs_bin.unsqueeze(dim=0).float())


### PR DESCRIPTION
I have implemented these watermark algorithm into vLLM and gained x40 time faster generation with effective watermark:
- KGW
- UPV
- Unigram

I hope this could be helpful for other researchers, such as in this [issue](https://github.com/THU-BPM/MarkLLM/issues/19).

The corresponding examples are included in [MarkvLLM_demo.py](https://github.com/zhangjf-nlp/MarkLLM/blob/MarkvLLM/MarkvLLM_demo.py)

Experimental verification (unwatermarked -> watermarked):
- Llama3-8b-Instruct with vLLM on c4

| vLLM | KGW | UPV | Unigram |
|-------|-----|-----|--------|
| PPL   | 1.191 -> 1.346 | 1.191 -> 0.926 | 1.191 -> 1.344 |
| detect | 0.001 -> 0.929 | 0.001 -> 0.430 | 0.001 -> 0.508 |
| time (h) | 0.19 -> 0.52 | 0.18 -> 2.02 | 0.18 -> 0.45 |

- Llama3-8b-Instruct with HF on c4

| HF | KGW | UPV | Unigram |
|-------|-----|-----|--------|
| detect | 0.001 -> 0.934 | 0.001 -> 0.358 | 0.001 -> 0.505 |
| time (h) | 20.00 -> 20.75 | 19.50 -> 21.50 | 20.50 -> 20.50 |
