### PR TITLE
Fix several bugs across watermark algorithms

### DIFF
--- a/watermark/adaptive/adaptive.py
+++ b/watermark/adaptive/adaptive.py
@@ -180,7 +180,8 @@ class AdaptiveUtils:
     def next_token_entropy(self, input_text, model, tokenizer, device):
         input_ids = tokenizer.encode(input_text, return_tensors='pt', add_special_tokens=False).to(device)
         outputs = model(input_ids)
-        probs = torch.nn.functional.softmax(outputs.logits[0, -1, :], dim=-1)
+        logits = outputs.logits[0, -1, :].float()
+        probs = torch.nn.functional.softmax(logits, dim=-1)
         mask = probs > 0
         entropy = -torch.sum(probs[mask] * torch.log(probs[mask]))
         return entropy
@@ -257,10 +258,10 @@ class Adaptive(BaseWatermark):
             # stopping criteria
             stop = self.utils.stopping_criteria(output_ids, self.config.generation_tokenizer)
             if stop:
-                output_text = self.config.generation_tokenizer.decode(output_ids[0].tolist())
+                output_text = self.config.generation_tokenizer.decode(output_ids[0].tolist(), skip_special_tokens=True)
                 return output_text
-        
-        output_text = self.config.generation_tokenizer.decode(output_ids[0])
+
+        output_text = self.config.generation_tokenizer.decode(output_ids[0].tolist(), skip_special_tokens=True)
         
         return output_text
     

--- a/watermark/dip/dip.py
+++ b/watermark/dip/dip.py
@@ -43,7 +43,11 @@ class DIPConfig(BaseConfig):
         self.ignore_history_detection = bool(self.config_dict['ignore_history_detection'])
         self.z_threshold = self.config_dict['z_threshold']
         self.prefix_length = self.config_dict['prefix_length']
-    
+        secret = self.config_dict.get('hash_key', self.config_dict.get('key'))
+        if secret is None:
+            raise ValueError("DIP config must set 'hash_key' or 'key' for RNG seed derivation.")
+        self.hash_key = str(secret).encode('utf-8')
+
     @property
     def algorithm_name(self) -> str:
         """Return the algorithm name."""

--- a/watermark/k_semstamp/k_semstamp.py
+++ b/watermark/k_semstamp/k_semstamp.py
@@ -75,6 +75,25 @@ class KSemStampUtils:
         """
         self.config = config
         self.rng = torch.Generator(device=self.config.device)
+        self._embedder = None
+        self._cluster_centers = None
+
+    def get_embedder(self) -> SentenceTransformer:
+        """Build and cache the SBERT embedder on first use."""
+        if self._embedder is None:
+            word_embedding_model = models.Transformer(self.config.path_to_embedder)
+            pooling_model = models.Pooling(
+                word_embedding_model.get_word_embedding_dimension(),
+                pooling_mode_mean_tokens=True,
+            )
+            self._embedder = SentenceTransformer(modules=[word_embedding_model, pooling_model])
+        return self._embedder
+
+    def get_cluster_centers(self):
+        """Load and cache the K-Means cluster centroids on first use."""
+        if self._cluster_centers is None:
+            self._cluster_centers = torch.load(self.config.path_to_centroids)
+        return self._cluster_centers
 
     @staticmethod
     def worker(rank, text_chunk, embedder_path, queue, encode_batch_size):
@@ -286,17 +305,8 @@ class KSemStamp(BaseWatermark):
 
     def generate_watermarked_text(self, prompt: str, *args, **kwargs) -> str:
         """Generate watermarked text using the KSEMSTAMP algorithm."""
-        # get cluster
-        cluster_centers=torch.load(self.config.path_to_centroids)
-        #cluster_centers = self.utils.generate_cluster()
-
-        # get embedder
-        word_embedding_model = models.Transformer(self.config.path_to_embedder)
-        pooling_model = models.Pooling(
-            word_embedding_model.get_word_embedding_dimension(),
-            pooling_mode_mean_tokens=True
-        )
-        embedder = SentenceTransformer(modules=[word_embedding_model, pooling_model])
+        cluster_centers = self.utils.get_cluster_centers()
+        embedder = self.utils.get_embedder()
 
         # instantiate sentence end criteria
         sent_end_criteria = KSemStampUtils.SentenceEndCriteria(self.config.generation_tokenizer)
@@ -355,15 +365,8 @@ class KSemStamp(BaseWatermark):
     
     def detect_watermark(self, text: str, return_dict: bool = True, *args, **kwargs):
         """Detect watermark in the input text."""
-        # get cluster
-        cluster_centers = torch.load(self.config.path_to_centroids)
-        # get embedder
-        word_embedding_model = models.Transformer(self.config.path_to_embedder)
-        pooling_model = models.Pooling(
-            word_embedding_model.get_word_embedding_dimension(),
-            pooling_mode_mean_tokens=True
-        )
-        embedder = SentenceTransformer(modules=[word_embedding_model, pooling_model])
+        cluster_centers = self.utils.get_cluster_centers()
+        embedder = self.utils.get_embedder()
 
         sentences = sent_tokenize(text)
         n_sent = len(sentences)

--- a/watermark/semstamp/semstamp.py
+++ b/watermark/semstamp/semstamp.py
@@ -67,6 +67,18 @@ class SemStampUtils:
         """
         self.config = config
         self.rng = torch.Generator(device=self.config.device)
+        self._lsh_model = None
+
+    def get_lsh_model(self):
+        """Build and cache the SBERT LSH model on first use."""
+        if self._lsh_model is None:
+            self._lsh_model = self.SBERTLSHModel(
+                lsh_model_path=self.config.path_to_embedder,
+                batch_size=1,
+                lsh_dim=self.config.dimension_d,
+                sbert_type='base',
+            )
+        return self._lsh_model
 
     class SBERTLSHModel:
         """Helper class for SBERTLSHModel"""
@@ -184,11 +196,7 @@ class SemStamp(BaseWatermark):
 
     def generate_watermarked_text(self, prompt: str, *args, **kwargs) -> str:
         """Generate watermarked text using the SEMSTAMP algorithm."""
-
-        # get LSH
-        lsh_model = self.utils.SBERTLSHModel(
-            lsh_model_path=self.config.path_to_embedder, batch_size=1, lsh_dim=self.config.dimension_d, sbert_type='base'
-        )
+        lsh_model = self.utils.get_lsh_model()
 
         # instantiate sentence end criteria
         sent_end_criteria = SemStampUtils.SentenceEndCriteria(
@@ -293,21 +301,11 @@ class SemStamp(BaseWatermark):
 
     def detect_watermark(self, text: str, return_dict: bool = True, *args, **kwargs):
         """Detect watermark in the input text."""
-        # get embedder
-        word_embedding_model = models.Transformer(self.config.path_to_embedder)
-        pooling_model = models.Pooling(
-            word_embedding_model.get_word_embedding_dimension(),
-            pooling_mode_mean_tokens=True
-        )
-        embedder = SentenceTransformer(
-            modules=[word_embedding_model, pooling_model])
-
         sentences = sent_tokenize(text)
         n_sent = len(sentences)
         n_watermark = 0
 
-        lsh_model = self.utils.SBERTLSHModel(
-            lsh_model_path=self.config.path_to_embedder, batch_size=1, lsh_dim=self.config.dimension_d, sbert_type='base')
+        lsh_model = self.utils.get_lsh_model()
         lsh_seed = lsh_model.get_hash([sentences[0]])[0]
         n_bins = 2**self.config.dimension_d
         n_accept = int(n_bins * self.config.gamma)

--- a/watermark/steal/steal.py
+++ b/watermark/steal/steal.py
@@ -18,6 +18,7 @@
 # ============================================
 
 import torch
+import torch.nn.functional as F
 from functools import partial
 import math
 from ..base import BaseWatermark, BaseConfig
@@ -473,8 +474,9 @@ class SpoofedProcessor(LogitsProcessor):
                 ctx = tuple(input_ids[b][-self.prevctx_width :].cpu().tolist())
 
             # 1) {ABC}->D: most precise but generally sparse   abcd 4-gram abc->d
+            ctx_abcd = tuple(ctx) if ordered else tuple(sorted(ctx))
             boosts_abcd = self._get_boosts_with_cache(
-                tuple(sorted(ctx)), vocab_sz, ordered, device
+                ctx_abcd, vocab_sz, ordered, device
             )
             boosts += self.config.w_abcd * boosts_abcd
             total_w += self.config.w_abcd
@@ -485,7 +487,7 @@ class SpoofedProcessor(LogitsProcessor):
                 solo_boosts = []  # single token boosts, without any context
                 for tok in ctx:
                     solo_boosts.append(
-                        self._get_boosts_with_cache((tok,), vocab_sz, ordered, device)
+                        self._get_boosts_with_cache((tok,), vocab_sz, False, device)
                     )
 
                 # pair 2-gram, a->d
@@ -531,8 +533,9 @@ class SpoofedProcessor(LogitsProcessor):
             if self.config.w_empty > 0:
                 # 3) Just use the empty context {}->D for an additional ctx-independent boost
                 # (finding D that are strong + true)
+                empty_ctx = self.emptyctx if ordered else tuple()
                 boosts_empty = self._get_boosts_with_cache(
-                    tuple(), vocab_sz, ordered, device
+                    empty_ctx, vocab_sz, ordered, device
                 )
                 boosts += self.config.w_empty * boosts_empty
                 total_w += self.config.w_empty

--- a/watermark/ts/ts.py
+++ b/watermark/ts/ts.py
@@ -166,9 +166,8 @@ class TSUtils:
             gamma = self.gamma
 
         if process == 'process':
-        # get every token's gamma value and delta value
-          self.gamma_list = torch.cat([self.gamma_list, gamma])
-          self.delta_list = torch.cat([self.delta_list, delta])
+            self.gamma_list = torch.cat([self.gamma_list, gamma.detach().reshape(-1).to(self.gamma_list.dtype)])
+            self.delta_list = torch.cat([self.delta_list, delta.detach().reshape(-1).to(self.delta_list.dtype)])
 
         # generate greenlist, every token have different greenlist_id
         greenlist_size = int(self.vocab_size * gamma)
@@ -180,12 +179,12 @@ class TSUtils:
 
         return greenlist_ids, gamma, delta,gamma_len
 
-    def _compute_z_score(self, observed_count, T):
-        # count refers to number of green tokens, T is total number of tokens
-        var = torch.sum(self.gamma_list * (1 - self.gamma_list))
-        mean = torch.sum(self.gamma_list)
-        z = (observed_count - mean)/torch.sqrt(var)
-        return z
+    def _compute_z_score(self, observed_count, gammas):
+        var = torch.sum(gammas * (1 - gammas))
+        mean = torch.sum(gammas)
+        if var.item() <= 0:
+            return torch.zeros((), device=gammas.device, dtype=gammas.dtype)
+        return (observed_count - mean) / torch.sqrt(var)
 
     def _score_sequence(
         self,
@@ -204,11 +203,12 @@ class TSUtils:
 
         green_token_count = 0
         green_token_mask = [-1 for _ in range(self.config.prefix_length)]
+        detect_gammas = []
 
         for idx in range(self.config.prefix_length, len(input_ids)):
             curr_token = input_ids[idx]
             if "opt" in self.config.generation_model.name_or_path.lower():
-                greenlist_ids, gamma, delta, gamma_len = self._get_greenlist_ids(input_ids[:idx],"detect")
+                greenlist_ids, gamma, delta, _ = self._get_greenlist_ids(input_ids[:idx],"detect")
 
             else:
                 llama_str = self.tokenizer_llama.decode(input_ids[max(idx-5, 0):idx], add_special_tokens=False)
@@ -216,7 +216,9 @@ class TSUtils:
                 if len(ids_opt) == 0:
                     green_token_mask.append(False)
                     continue
-                greenlist_ids, gamma, delta, gamma_len = self._get_greenlist_ids(torch.tensor(ids_opt).to(self.device),"detect")
+                greenlist_ids, gamma, delta, _ = self._get_greenlist_ids(torch.tensor(ids_opt).to(self.device),"detect")
+
+            detect_gammas.append(gamma.detach().to(torch.float).reshape(-1))
 
             if curr_token in greenlist_ids:
                 green_token_count += 1
@@ -224,9 +226,12 @@ class TSUtils:
             else:
                 green_token_mask.append(False)
 
-        self.gamma_list = self.gamma_list[self.config.prefix_length:]
+        if not detect_gammas:
+            z_score = torch.zeros((), device=self.device, dtype=torch.float)
+            return z_score, green_token_mask
 
-        z_score = self._compute_z_score(green_token_count, num_tokens_scored)
+        gammas = torch.cat(detect_gammas)
+        z_score = self._compute_z_score(green_token_count, gammas)
 
         return z_score, green_token_mask
 

--- a/watermark/unbiased/unbiased.py
+++ b/watermark/unbiased/unbiased.py
@@ -251,7 +251,11 @@ class UnbiasedUtils:
     
     def value_transformation(self, value: float) -> float:
         """Transform value to range [0, 1]."""
-        return value/(value + 1)
+        v = float(value)
+        d = v + 1.0
+        if d == 0.0:
+            return 0.0
+        return float(v / d)
     
     def score_sequence(self, text: str) -> tuple[float, list[int]]:
         """Score the input_ids and return z_score and green_token_flags."""
@@ -298,8 +302,8 @@ class UnbiasedUtils:
         unclipped_scores = torch.gather(llr, -1, labels.unsqueeze(-1)).squeeze(-1)
         ## shape = (batch_size, seq_len - prefix_length, query_size)
         scores = torch.clamp(unclipped_scores.unsqueeze(-1), min_llr, max_llr)
-        scores = np.array(scores[0].cpu())
-        labels = np.array(labels[0].cpu())
+        scores = scores[0].float().cpu().numpy()
+        labels = labels[0].cpu().numpy()
         
         # Step 5: Choose the best index for grid search
         sum_scores = np.sum(scores, axis=0)
@@ -320,8 +324,8 @@ class UnbiasedUtils:
                 highlight_values[position] = self.value_transformation(score)
         
         ## Theorem 9: p <= A * e^(-t)
-        p_val = n * np.exp(-final_score)
-        
+        p_val = float(n * np.exp(-final_score))
+
         return p_val, highlight_values
 
 class UnbiasedLogitsProcessor(LogitsProcessor):

--- a/watermark/xsir/xsir.py
+++ b/watermark/xsir/xsir.py
@@ -108,6 +108,9 @@ class XSIRUtils:
             model_name=self.config.transform_model_name,
             input_dim=config.transform_model_input_dim
         ).to(self.config.device, dtype=torch.float32)
+        self.transform_model.eval()
+        for param in self.transform_model.parameters():
+            param.requires_grad_(False)
         self.mapping = self._get_mapping(self.config.mapping_name)
 
     def get_embedding(self, sentence: str) -> torch.FloatTensor:


### PR DESCRIPTION
### Summary

While integrating these algorithms I hit a number of independent bugs. Each
is fixed in its own commit so they can be reviewed (or reverted) individually.

| Algorithm | Bug | Fix |
|---|---|---|
| **DIP** | `DIPConfig` never set `self.hash_key`, but `DIPUtils._get_rng_seed()` hashes it and the config only ships `key` — so **every** generation/detection raised `AttributeError: 'DIPConfig' object has no attribute 'hash_key'`. | Read `hash_key` (falling back to `key`) and store it as bytes. |
| **Unbiased** | Detection did `np.array(tensor)` on the score tensor; numpy has no bf16/fp16 dtype, so with a half-precision model it raised `TypeError: Got unsupported ScalarType BFloat16`. | Cast to float32 before `.numpy()`; also guard a zero denominator and return a Python-float p-value. |
| **XSIR** | Recent `sentence-transformers` wrap `.encode()` in `torch.inference_mode()`; feeding those inference tensors through the grad-enabled transform model raised `RuntimeError: Inference tensors cannot be saved for backward`. | The transform model is inference-only — put it in `eval()` and disable `requires_grad` on its parameters. |
| **TS** | Detection derived its z-score from the instance-level `gamma_list` that is only filled while *this* instance generates text, and destructively sliced it each call. On any externally supplied text the list was empty → variance 0 → `NaN`/`Inf` z-scores; repeated detects also drifted. | Accumulate per-token greenlist fractions locally for the scored text; `_compute_z_score` now takes them explicitly and returns 0 on degenerate variance. |
| **SemStamp / KSemStamp** | The SBERT embedder (and KSemStamp's centroids) were reloaded from disk on *every* generate/detect call; SemStamp's `detect_watermark` also built a second, unused `SentenceTransformer`. | Build them once and cache on the utils object; drop the dead embedder. Behaviour unchanged. |
| **Adaptive** | Output was decoded without `skip_special_tokens`, leaking `</s>`/`<pad>` into the returned text (and downstream detection/metrics); entropy was computed on raw (possibly bf16) logits. | Pass `skip_special_tokens=True` on both decode paths; upcast logits to float32 before the entropy softmax. |
| **STEAL** | `SpoofedProcessor.__call__` used `F.cosine_similarity` without importing `torch.nn.functional`, and looked up boosts with the wrong keys (sorted context for the ordered store, the `ordered` flag on single-token queries, `()` for the ordered empty-context key). | Add the import and use the correct key per store / per path. |

### Testing

Each fix was verified on a GPU (CUDA 12.4) with the trained checkpoints / count
tables for the method in question:

- **DIP** — crashed before the fix; now runs as intended, with `facebook/opt-1.3b`.
- **Unbiased** — reproduced the bf16 `TypeError`; detection now runs with a bf16 model.
- **XSIR** — reproduced the exact "Inference tensors cannot be saved for backward" error and confirmed the freeze fixes it.
- **TS** — with the trained OPT checkpoint, a fresh detector (text it did not itself generate) now yields a finite z-score (8.36 watermarked vs −0.22 unwatermarked); the old code produced `inf` from the empty `gamma_list`. Repeated detection of the same text is now stable.
- **SemStamp / KSemStamp** — the SBERT model now loads once and is reused (same object); centroids likewise. Detection runs end-to-end on the cached model.
- **Adaptive** — with a bf16 measurement model the entropy is a finite float32 value; generated text no longer contains special tokens (base decode `"</s>Good Morning!"` → fixed `"Good Morning!"`).
- **STEAL** — driving `SpoofedProcessor` with the real count tables (`ordered=True`, `w_partials>0`, `w_empty>0`): on the base code the missing import raises `NameError`, the ordered single-token and empty-context lookups raise `ValueError`, and the sorted key silently returns zero boosts; the fixed processor runs end-to-end and boosts the logits.