### PR TITLE
Add SSG logit-balanced watermarking

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@
 As the MarkLLM repository content becomes increasingly rich and its size grows larger, we have created a model storage repository on Hugging Face called [Generative-Watermark-Toolkits](https://huggingface.co/Generative-Watermark-Toolkits) to facilitate usage. This repository contains various default models for watermarking algorithms that involve self-trained models. We have removed the model weights from the corresponding `model/` folders of these watermarking algorithms in the main repository. **When using the code, please first download the corresponding models from the Hugging Face repository according to the config paths and save them to the `model/` directory before running the code.**
 
 ### Updates
+- 🎉 **(2026.08.18)** Add [SSG](https://arxiv.org/abs/2604.22438) watermarking method.
 - 🎉 **(2025.09.22)** Add [SemStamp](https://arxiv.org/abs/2310.03991) watermark method. Thanks Huan Wang for her PR!
 - 🎉 **(2025.09.17)** Add [IE](https://arxiv.org/abs/2505.14112) watermark method. Thanks Tianle Gu for her PR!
 - 🎉 **(2025.09.14)** Add [Watermark Stealing](https://arxiv.org/abs/2402.19361) attack method. Thanks Shuhao Zhang for his PR!
@@ -147,6 +148,7 @@ MarkLLM is an open-source toolkit developed to facilitate the research and appli
   | SWEET              | ACL 2024    | [\[2305.15060\] Who Wrote this Code? Watermarking for Code Generation (arxiv.org)](https://arxiv.org/abs/2305.15060)                                                            |
   | UPV                | ICLR 2024    | [\[2307.16230\] An Unforgeable Publicly Verifiable Watermark for Large Language Models (arxiv.org)](https://arxiv.org/abs/2307.16230)                                           |
   | EWD                | ACL 2024    | [\[2403.13485\] An Entropy-based Text Watermarking Detection Method (arxiv.org)](https://arxiv.org/abs/2403.13485)                                                              |
+  | SSG                | ACL 2026    | [\[2604.22438\] SSG: Logit-Balanced Vocabulary Partitioning for LLM Watermarking (arxiv.org)](https://arxiv.org/abs/2604.22438)                                                  |
   | SIR                | ICLR 2024    | [\[2310.06356\] A Semantic Invariant Robust Watermark for Large Language Models (arxiv.org)](https://arxiv.org/abs/2310.06356)                                                  |
   | X-SIR              | ACL 2024    | [\[2402.14007\] Can Watermarks Survive Translation? On the Cross-lingual Consistency of Text Watermark for Large Language Models (arxiv.org)](https://arxiv.org/abs/2402.14007) |
   | DiPmark            | ICML 2024    | [\[2310.07710\] A Resilient and Accessible Distribution-Preserving Watermark for Large Language Models (arxiv.org)](https://arxiv.org/abs/2310.07710)                           |

--- a/config/SSG.json
+++ b/config/SSG.json
@@ -1,0 +1,11 @@
+{
+    "algorithm_name": "SSG",
+    "gamma": 0.5,
+    "delta": 2.0,
+    "hash_key": 15485863,
+    "prefix_length": 1,
+    "z_threshold": 2.0,
+    "topk": 4,
+    "detection_method": "EWD",
+    "detection_entropy_threshold": 0.9
+}

--- a/test/test_method.py
+++ b/test/test_method.py
@@ -37,7 +37,7 @@ def test_algorithm(algorithm_name):
     assert algorithm_name in ['KGW', 'Unigram', 'SWEET', 'EWD', 'SIR',
                               'XSIR', 'DIP', 'Unbiased', 'UPV', 'TS',
                               'SynthID', 'EXP', 'EXPGumbel', 'EXPEdit',
-                              'ITSEdit', 'PF', 'MorphMark', 'Adaptive', 'KSEMSTAMP','SEMSTAMP', 'IE']
+                              'ITSEdit', 'PF', 'MorphMark', 'Adaptive', 'KSEMSTAMP','SEMSTAMP', 'IE', 'SSG']
 
     # Device
     device = "cuda" if torch.cuda.is_available() else "cpu"

--- a/test/test_ssg.py
+++ b/test/test_ssg.py
@@ -1,0 +1,162 @@
+# Copyright 2026 THU-BPM MarkLLM.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+from types import SimpleNamespace
+
+import torch
+
+from watermark.auto_config import config_name_from_alg_name
+from watermark.auto_watermark import AutoWatermark, watermark_name_from_alg_name
+from watermark.ssg.ssg import SSG, SSGConfig, SSGLogitsProcessor, SSGUtils
+from utils.transformers_config import TransformersConfig
+
+
+def _config(detection_method="KGW"):
+    config = SSGConfig.__new__(SSGConfig)
+    config.gamma = 0.5
+    config.delta = 2.0
+    config.hash_key = 15485863
+    config.prefix_length = 1
+    config.topk = 4
+    config.vocab_size = 8
+    config.device = "cpu"
+    config.detection_method = detection_method
+    config.detection_entropy_threshold = 0.9
+    return config
+
+
+def test_ssg_is_registered_with_auto_classes():
+    assert config_name_from_alg_name("SSG") == "watermark.ssg.SSGConfig"
+    assert watermark_name_from_alg_name("SSG") == "watermark.ssg.SSG"
+
+
+def test_greenlist_is_balanced_exact_and_deterministic():
+    utils = SSGUtils(_config())
+    input_ids = torch.tensor([3, 5])
+    scores = torch.tensor([8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0])
+
+    first_greenlist = utils.get_greenlist_ids(input_ids, scores)
+    second_greenlist = utils.get_greenlist_ids(input_ids, scores)
+
+    assert torch.equal(first_greenlist, second_greenlist)
+    assert len(first_greenlist) == 4
+    assert len(torch.unique(first_greenlist)) == 4
+    assert sum(token in first_greenlist for token in (0, 1)) == 1
+    assert sum(token in first_greenlist for token in (2, 3)) == 1
+
+
+def test_logits_processor_partitions_each_batch_row_independently():
+    config = _config()
+    utils = SSGUtils(config)
+    processor = SSGLogitsProcessor(config, utils)
+    input_ids = torch.tensor([[1, 2], [6, 7]])
+    scores = torch.tensor(
+        [
+            [8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0],
+            [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+        ]
+    )
+    original_scores = scores.clone()
+    expected_greenlists = [
+        utils.get_greenlist_ids(input_ids[index], original_scores[index])
+        for index in range(2)
+    ]
+
+    processed_scores = processor(input_ids, scores)
+
+    for index, greenlist in enumerate(expected_greenlists):
+        expected_delta = torch.zeros(config.vocab_size)
+        expected_delta[greenlist] = config.delta
+        assert torch.equal(
+            processed_scores[index] - original_scores[index], expected_delta
+        )
+
+
+def test_score_sequence_returns_aligned_finite_kgw_data():
+    config = _config("KGW")
+    utils = SSGUtils(config)
+    input_ids = torch.tensor([1, 3, 4, 2])
+    logits = torch.tensor(
+        [
+            [
+                [8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0],
+                [1.0, 8.0, 2.0, 7.0, 3.0, 6.0, 4.0, 5.0],
+                [5.0, 4.0, 3.0, 2.0, 1.0, 8.0, 7.0, 6.0],
+                [8.0, 1.0, 7.0, 2.0, 6.0, 3.0, 5.0, 4.0],
+            ]
+        ]
+    )
+    entropy = [-10000.0, 0.5, 0.8, 0.7]
+
+    score, flags, weights = utils.score_sequence(input_ids, entropy, logits)
+
+    assert math.isfinite(score)
+    assert len(flags) == len(input_ids)
+    assert flags[0] == -1
+    assert set(flags[1:]) <= {0, 1}
+    assert weights == [-1.0, 1.0, 1.0, 1.0]
+
+
+def test_zero_ewd_variance_produces_neutral_score():
+    utils = SSGUtils(_config("EWD"))
+
+    assert utils._compute_z_score(0.0, [0.0, 0.0]) == 0.0
+
+
+class _Encoding(dict):
+    def to(self, device):
+        return _Encoding({key: value.to(device) for key, value in self.items()})
+
+
+class _Tokenizer:
+    def __call__(self, text, return_tensors, add_special_tokens):
+        token_ids = [int(token) for token in text.split()]
+        if add_special_tokens:
+            token_ids.insert(0, 0)
+        return _Encoding(input_ids=torch.tensor([token_ids]))
+
+    def decode(self, token_id):
+        return str(token_id)
+
+
+class _Model:
+    def __call__(self, input_ids, return_dict):
+        base_logits = torch.arange(8, dtype=torch.float)
+        logits = torch.stack(
+            [base_logits * (index + 1) for index in range(input_ids.shape[1])]
+        ).unsqueeze(0)
+        return SimpleNamespace(logits=logits)
+
+
+def test_detection_and_visualization_use_the_markllm_interfaces():
+    transformers_config = TransformersConfig(
+        model=_Model(), tokenizer=_Tokenizer(), vocab_size=8, device="cpu"
+    )
+    watermark = AutoWatermark.load(
+        "SSG",
+        algorithm_config="config/SSG.json",
+        transformers_config=transformers_config,
+    )
+
+    result = watermark.detect_watermark("1 3 4")
+    visualization = watermark.get_data_for_visualization("1 3 4")
+
+    assert set(result) == {"is_watermarked", "score"}
+    assert isinstance(watermark, SSG)
+    assert isinstance(result["is_watermarked"], bool)
+    assert math.isfinite(result["score"])
+    assert visualization.decoded_tokens == ["0", "1", "3", "4"]
+    assert len(visualization.highlight_values) == 4
+    assert len(visualization.weights) == 4

--- a/test/test_visualize.py
+++ b/test/test_visualize.py
@@ -104,7 +104,7 @@ def test_visualization_without_weight(algorithm_name, visualize_type='discrete')
     # Validate input
     assert visualize_type in ['discrete', 'continuous']
     if visualize_type == 'discrete':
-        assert algorithm_name in ['KGW', 'Unigram', 'SWEET', 'UPV', 'SIR', 'XSIR', 'EWD', 'DIP', 'Unbiased']
+        assert algorithm_name in ['KGW', 'Unigram', 'SWEET', 'UPV', 'SIR', 'XSIR', 'EWD', 'DIP', 'Unbiased', 'SSG']
     else:
         assert algorithm_name in ['EXP', 'EXPEdit', 'ITSEdit', 'EXPGumbel']
 
@@ -141,7 +141,7 @@ def test_visualization_without_weight(algorithm_name, visualize_type='discrete')
 
 def test_visualization_with_weight(algorithm_name):
     # Validate input
-    assert algorithm_name in ['SWEET', 'EWD']
+    assert algorithm_name in ['SWEET', 'EWD', 'SSG']
 
     # Get data for visualization
     watermarked_data, unwatermarked_data = get_data(algorithm_name)

--- a/watermark/auto_config.py
+++ b/watermark/auto_config.py
@@ -45,7 +45,8 @@ CONFIG_MAPPING_NAMES = {
     'Adaptive': 'watermark.adaptive.AdaptiveConfig',
     "KSEMSTAMP": 'watermark.k_semstamp.KSemStampConfig',
     "SEMSTAMP": 'watermark.semstamp.SemStampConfig',
-    "IE": "watermark.ie.IEConfig"
+    "IE": "watermark.ie.IEConfig",
+    "SSG": "watermark.ssg.SSGConfig"
 }
 
 

--- a/watermark/auto_watermark.py
+++ b/watermark/auto_watermark.py
@@ -45,7 +45,8 @@ WATERMARK_MAPPING_NAMES = {
     'Adaptive': 'watermark.adaptive.Adaptive',
     "KSEMSTAMP": 'watermark.k_semstamp.KSemStamp',
     "SEMSTAMP": 'watermark.semstamp.SemStamp',
-    "IE": "watermark.ie.IE"
+    "IE": "watermark.ie.IE",
+    "SSG": "watermark.ssg.SSG"
 }
 
 

--- a/watermark/ssg/__init__.py
+++ b/watermark/ssg/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2026 Chenxi Gu, Xiaoning Du, and John Grundy.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .ssg import SSG, SSGConfig
+
+__all__ = ["SSG", "SSGConfig"]

--- a/watermark/ssg/ssg.py
+++ b/watermark/ssg/ssg.py
@@ -1,0 +1,305 @@
+# Copyright 2026 Chenxi Gu, Xiaoning Du, and John Grundy.
+# Copyright 2024 THU-BPM MarkLLM.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SSG: Logit-Balanced Vocabulary Partitioning for LLM Watermarking.
+
+Adapted from the authors' implementation at https://github.com/Leileileisa/SSG.
+"""
+
+import math
+from functools import partial
+
+import torch
+from transformers import LogitsProcessor, LogitsProcessorList
+
+from utils.transformers_config import TransformersConfig
+from visualize.data_for_visualization import DataForVisualization
+from watermark.base import BaseConfig, BaseWatermark
+
+
+class SSGConfig(BaseConfig):
+    """Configuration for the SSG algorithm."""
+
+    def initialize_parameters(self) -> None:
+        self.gamma = self.config_dict["gamma"]
+        self.delta = self.config_dict["delta"]
+        self.hash_key = self.config_dict["hash_key"]
+        self.z_threshold = self.config_dict["z_threshold"]
+        self.prefix_length = self.config_dict["prefix_length"]
+        self.topk = self.config_dict["topk"]
+        self.detection_method = self.config_dict["detection_method"].upper()
+        self.detection_entropy_threshold = self.config_dict[
+            "detection_entropy_threshold"
+        ]
+
+        if not 0 < self.gamma < 1:
+            raise ValueError("gamma must be between 0 and 1")
+        if self.prefix_length < 1:
+            raise ValueError("prefix_length must be at least 1")
+        if self.topk < 2 or self.topk > self.vocab_size or self.topk % 2:
+            raise ValueError("topk must be an even integer between 2 and vocab_size")
+        if self.detection_method not in {"EWD", "KGW", "SWEET"}:
+            raise ValueError("detection_method must be EWD, KGW, or SWEET")
+
+        target_green = int(self.vocab_size * self.gamma)
+        paired_green = self.topk // 2
+        tail_size = self.vocab_size - self.topk
+        if not paired_green <= target_green <= paired_green + tail_size:
+            raise ValueError(
+                "gamma and topk cannot produce the requested green-list size"
+            )
+
+    @property
+    def algorithm_name(self) -> str:
+        return "SSG"
+
+
+class SSGUtils:
+    """Vocabulary partitioning and detection utilities for SSG."""
+
+    def __init__(self, config: SSGConfig, *args, **kwargs) -> None:
+        self.config = config
+        self.rng = torch.Generator(device=self.config.device)
+        alpha = math.exp(self.config.delta)
+        self.z_value = ((1 - self.config.gamma) * (alpha - 1)) / (
+            1 - self.config.gamma + alpha * self.config.gamma
+        )
+
+    def _seed_rng(
+        self, input_ids: torch.LongTensor, first_token: int, second_token: int
+    ) -> None:
+        """Seed the RNG from the secret key, context, and a token pair."""
+        context_hash = 1
+        for token in input_ids[-self.config.prefix_length :]:
+            context_hash *= token.item()
+        context_hash %= self.config.vocab_size
+        pair_hash = (first_token + second_token) % self.config.vocab_size
+        self.rng.manual_seed(self.config.hash_key * context_hash + pair_hash)
+
+    def get_greenlist_ids(
+        self, input_ids: torch.LongTensor, scores: torch.FloatTensor
+    ) -> torch.LongTensor:
+        """Create the logit-balanced green list for one generation step."""
+        scores = scores.reshape(-1)
+        if scores.numel() != self.config.vocab_size:
+            raise ValueError(
+                f"Expected {self.config.vocab_size} scores, got {scores.numel()}"
+            )
+
+        top_ids = torch.topk(
+            scores.float(), k=self.config.topk, largest=True, sorted=True
+        ).indices
+        green_ids = []
+
+        for index in range(0, self.config.topk, 2):
+            first = int(top_ids[index].item())
+            second = int(top_ids[index + 1].item())
+            self._seed_rng(input_ids, first, second)
+            choice = int(
+                torch.randint(
+                    0,
+                    2,
+                    (1,),
+                    device=scores.device,
+                    generator=self.rng,
+                ).item()
+            )
+            green_ids.append(min(first, second) if choice == 0 else max(first, second))
+
+        vocab_ids = torch.arange(
+            self.config.vocab_size, device=scores.device, dtype=torch.long
+        )
+        tail_mask = torch.ones(
+            self.config.vocab_size, device=scores.device, dtype=torch.bool
+        )
+        tail_mask[top_ids] = False
+        tail_ids = vocab_ids[tail_mask]
+
+        remaining_green = int(self.config.vocab_size * self.config.gamma) - len(
+            green_ids
+        )
+        if remaining_green:
+            self._seed_rng(input_ids, 0, 0)
+            permutation = torch.randperm(
+                tail_ids.numel(), device=scores.device, generator=self.rng
+            )
+            green_ids.extend(tail_ids[permutation[:remaining_green]].tolist())
+
+        return torch.tensor(green_ids, device=scores.device, dtype=torch.long)
+
+    def calculate_entropy(
+        self, model, tokenized_text: torch.LongTensor
+    ) -> tuple[list[float], torch.FloatTensor]:
+        """Calculate EWD's entropy-derived weights and return the model logits."""
+        with torch.no_grad():
+            output = model(torch.unsqueeze(tokenized_text, 0), return_dict=True)
+            probabilities = torch.softmax(output.logits, dim=-1)
+            renormalized = probabilities / (1 + self.z_value * probabilities)
+            entropy = renormalized.sum(dim=-1)[0].cpu().tolist()
+            entropy.insert(0, -10000.0)
+            return entropy[:-1], output.logits
+
+    def _get_weights(self, entropy_list: list[float]) -> list[float]:
+        entropy = torch.tensor(entropy_list)
+        scored_entropy = entropy[self.config.prefix_length :]
+
+        if self.config.detection_method == "EWD":
+            scored_weights = scored_entropy - torch.min(scored_entropy)
+        elif self.config.detection_method == "KGW":
+            scored_weights = torch.ones_like(scored_entropy)
+        else:
+            scored_weights = torch.where(
+                scored_entropy > self.config.detection_entropy_threshold,
+                1.0,
+                0.01,
+            )
+
+        return [-1.0] * self.config.prefix_length + scored_weights.tolist()
+
+    def _compute_z_score(self, observed_count: float, weights: list[float]) -> float:
+        weight_tensor = torch.tensor(weights, dtype=torch.float)
+        variance = (
+            torch.square(weight_tensor).sum()
+            * self.config.gamma
+            * (1 - self.config.gamma)
+        )
+        if variance <= 0:
+            return 0.0
+        expected_count = self.config.gamma * weight_tensor.sum()
+        return ((observed_count - expected_count) / torch.sqrt(variance)).item()
+
+    def score_sequence(
+        self,
+        input_ids: torch.LongTensor,
+        entropy_list: list[float],
+        scores: torch.FloatTensor,
+    ) -> tuple[float, list[int], list[float]]:
+        """Score a token sequence by reconstructing each SSG green list."""
+        num_tokens_scored = len(input_ids) - self.config.prefix_length
+        if num_tokens_scored < 1:
+            raise ValueError(
+                "Must have at least one token after the prefix required by SSG"
+            )
+
+        green_token_flags = [-1] * self.config.prefix_length
+        for index in range(self.config.prefix_length, len(input_ids)):
+            green_ids = self.get_greenlist_ids(
+                input_ids[:index], scores[0, index - 1, :]
+            )
+            is_green = torch.any(green_ids == input_ids[index]).item()
+            green_token_flags.append(int(is_green))
+
+        weights = self._get_weights(entropy_list)
+        observed_count = sum(
+            weights[index] for index, flag in enumerate(green_token_flags) if flag == 1
+        )
+        z_score = self._compute_z_score(
+            observed_count, weights[self.config.prefix_length :]
+        )
+        return z_score, green_token_flags, weights
+
+
+class SSGLogitsProcessor(LogitsProcessor):
+    """Apply SSG's logit-balanced green-list bias."""
+
+    def __init__(self, config: SSGConfig, utils: SSGUtils, *args, **kwargs) -> None:
+        self.config = config
+        self.utils = utils
+
+    def __call__(
+        self, input_ids: torch.LongTensor, scores: torch.FloatTensor
+    ) -> torch.FloatTensor:
+        if input_ids.shape[-1] < self.config.prefix_length:
+            return scores
+
+        green_mask = torch.zeros_like(scores, dtype=torch.bool)
+        for batch_index in range(input_ids.shape[0]):
+            green_ids = self.utils.get_greenlist_ids(
+                input_ids[batch_index], scores[batch_index]
+            )
+            green_mask[batch_index, green_ids] = True
+
+        scores[green_mask] += self.config.delta
+        return scores
+
+
+class SSG(BaseWatermark):
+    """Top-level SSG watermark implementation."""
+
+    def __init__(
+        self,
+        algorithm_config: str | SSGConfig,
+        transformers_config: TransformersConfig | None = None,
+        *args,
+        **kwargs,
+    ) -> None:
+        if isinstance(algorithm_config, str):
+            self.config = SSGConfig(algorithm_config, transformers_config)
+        elif isinstance(algorithm_config, SSGConfig):
+            self.config = algorithm_config
+        else:
+            raise TypeError(
+                "algorithm_config must be either a path string or an SSGConfig instance"
+            )
+
+        self.utils = SSGUtils(self.config)
+        self.logits_processor = SSGLogitsProcessor(self.config, self.utils)
+
+    def generate_watermarked_text(self, prompt: str, *args, **kwargs) -> str:
+        generate_with_watermark = partial(
+            self.config.generation_model.generate,
+            logits_processor=LogitsProcessorList([self.logits_processor]),
+            **self.config.gen_kwargs,
+        )
+        encoded_prompt = self.config.generation_tokenizer(
+            prompt, return_tensors="pt", add_special_tokens=True
+        ).to(self.config.device)
+        encoded_text = generate_with_watermark(**encoded_prompt)
+        return self.config.generation_tokenizer.batch_decode(
+            encoded_text, skip_special_tokens=True
+        )[0]
+
+    def detect_watermark(
+        self, text: str, return_dict: bool = True, *args, **kwargs
+    ) -> dict | tuple:
+        encoded_text = self.config.generation_tokenizer(
+            text, return_tensors="pt", add_special_tokens=True
+        )["input_ids"][0].to(self.config.device)
+        entropy_list, scores = self.utils.calculate_entropy(
+            self.config.generation_model, encoded_text
+        )
+        z_score, _, _ = self.utils.score_sequence(encoded_text, entropy_list, scores)
+        is_watermarked = z_score > self.config.z_threshold
+        if return_dict:
+            return {"is_watermarked": is_watermarked, "score": z_score}
+        return is_watermarked, z_score
+
+    def get_data_for_visualization(
+        self, text: str, *args, **kwargs
+    ) -> DataForVisualization:
+        encoded_text = self.config.generation_tokenizer(
+            text, return_tensors="pt", add_special_tokens=True
+        )["input_ids"][0].to(self.config.device)
+        entropy_list, scores = self.utils.calculate_entropy(
+            self.config.generation_model, encoded_text
+        )
+        _, highlight_values, weights = self.utils.score_sequence(
+            encoded_text, entropy_list, scores
+        )
+        decoded_tokens = [
+            self.config.generation_tokenizer.decode(token_id.item())
+            for token_id in encoded_text
+        ]
+        return DataForVisualization(decoded_tokens, highlight_values, weights)


### PR DESCRIPTION
## Summary

- add SSG (ACL 2026), a logit-balanced vocabulary partitioning watermark for low-entropy and general text generation
- integrate SSG with `AutoConfig`, `AutoWatermark`, generation, detection, and weighted visualization
- add the official default configuration and document the paper in the supported algorithm list
- make the reference approach CPU/device agnostic and correct per-row handling for batched logits
- add focused tests for deterministic balanced partitioning, exact green-list size, batched processing, detection, visualization, and automatic loading

## References

- Paper: https://arxiv.org/abs/2604.22438
- Official implementation: https://github.com/Leileileisa/SSG

The implementation is adapted from the Apache-2.0 official code and keeps attribution in the source.

## Testing

- `uv run --python 3.12 --with pytest --with torch --with transformers python -m pytest test/test_ssg.py -q` (6 passed)
- `uvx --from ruff==0.15.7 ruff format --check watermark/ssg test/test_ssg.py`
- `uvx --from ruff==0.15.7 ruff check watermark/ssg test/test_ssg.py`
- `python3 -m compileall -q watermark/ssg test/test_ssg.py`
- `python3 -m json.tool config/SSG.json`
- `git diff --check`
