### PR TITLE
Add E2E learned watermarking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ evaluation/examples/tools.py
 # Model
 watermark/sir/model/compositional-bert-large-uncased/
 watermark/xsir/model/paraphrase-multilingual-mpnet-base-v2/
+watermark/e2e/model/*.pth
 
 # Figures
 test_images/

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ MarkLLM is an open-source toolkit developed to facilitate the research and appli
   | EXP-Edit           | TMLR 2024 | [\[2307.15593\] Robust Distortion-free Watermarks for Language Models (arxiv.org)](https://arxiv.org/abs/2307.15593)                                                           |
   | ITS-Edit           | TMLR 2024 | [\[2307.15593\] Robust Distortion-free Watermarks for Language Models (arxiv.org)](https://arxiv.org/abs/2307.15593)                                                           |
   | IE           | Arxiv Preprint | [\[2505.14112\] Invisible Entropy: Towards Safe and Efficient Low-Entropy LLM Watermarking (arxiv.org)](https://arxiv.org/abs/2505.14112)                                                           |
+  | E2E-LLM-Watermark | ICML 2025 | [\[2505.02344\] An End-to-End Model For Logits Based Large Language Models Watermarking](https://arxiv.org/abs/2505.02344) |
 - **Visualization Solutions:** The toolkit includes custom visualization tools that enable clear and insightful views into how different watermarking algorithms operate under various scenarios. These visualizations help demystify the algorithms' mechanisms, making them more understandable for users.
 
   <img src="images\mechanism_visualization.png" alt="mechanism_visualization" style="zoom:35%;" />

--- a/config/E2E.json
+++ b/config/E2E.json
@@ -1,0 +1,14 @@
+{
+    "algorithm_name": "E2E",
+    "delta": 1.25,
+    "top_k": 20,
+    "window_size": 10,
+    "detection_threshold": 0.5,
+    "checkpoint_path": "watermark/e2e/model/35000.pth",
+    "reference_model_name": "facebook/opt-1.3b",
+    "reference_tokenizer_name": "facebook/opt-1.3b",
+    "tokenizer_conversion_multiplier": 3,
+    "mapper_layers": 5,
+    "hidden_dim": 64,
+    "detector_layers": 3
+}

--- a/test/test_e2e.py
+++ b/test/test_e2e.py
@@ -1,0 +1,176 @@
+# Copyright 2026 THU-BPM MarkLLM.
+# Licensed under the Apache License, Version 2.0.
+
+import json
+import math
+
+import torch
+
+from utils.transformers_config import TransformersConfig
+from watermark.auto_config import config_name_from_alg_name
+from watermark.auto_watermark import AutoWatermark, watermark_name_from_alg_name
+from watermark.e2e import E2E
+from watermark.e2e.model import E2EDetector, E2EEncoder
+
+
+class _Encoding(dict):
+    def to(self, device):
+        return _Encoding({key: value.to(device) for key, value in self.items()})
+
+
+class _Tokenizer:
+    pad_token_id = 0
+    eos_token_id = 0
+
+    def __init__(self, vocabulary_prefix="token"):
+        self.vocabulary_prefix = vocabulary_prefix
+
+    def __len__(self):
+        return 8
+
+    def get_vocab(self):
+        return {f"{self.vocabulary_prefix}-{index}": index for index in range(8)}
+
+    def __call__(self, text, return_tensors=None, add_special_tokens=False):
+        token_ids = [int(token) % 8 for token in text.split() if token.isdigit()]
+        if add_special_tokens:
+            token_ids.insert(0, self.eos_token_id)
+        if return_tensors == "pt":
+            return _Encoding(input_ids=torch.tensor([token_ids], dtype=torch.long))
+        return {"input_ids": token_ids}
+
+    def decode(self, token_ids, skip_special_tokens=False):
+        if isinstance(token_ids, int):
+            token_ids = [token_ids]
+        elif isinstance(token_ids, torch.Tensor) and token_ids.ndim == 0:
+            token_ids = [int(token_ids)]
+        return " ".join(str(int(token_id)) for token_id in token_ids)
+
+    def batch_decode(self, sequences, skip_special_tokens=False):
+        return [self.decode(sequence, skip_special_tokens) for sequence in sequences]
+
+
+class _Model(torch.nn.Module):
+    def __init__(self, embedding_dim=4):
+        super().__init__()
+        self.embeddings = torch.nn.Embedding(8, embedding_dim)
+
+    def get_input_embeddings(self):
+        return self.embeddings
+
+    def generate(self, input_ids, logits_processor=None, max_new_tokens=2, **kwargs):
+        output = input_ids.clone()
+        base_scores = torch.arange(8, dtype=torch.float).repeat(output.shape[0], 1)
+        for _ in range(max_new_tokens):
+            scores = base_scores.clone()
+            if logits_processor is not None:
+                scores = logits_processor(output, scores)
+            next_token = scores.argmax(dim=-1, keepdim=True)
+            output = torch.cat([output, next_token], dim=-1)
+        return output
+
+
+def _write_checkpoint(path):
+    torch.manual_seed(7)
+    encoder = E2EEncoder(input_dim=4, mapper_layers=2, window_size=3, hidden_dim=4)
+    detector = E2EDetector(input_dim=4, hidden_dim=4, num_layers=1)
+    torch.save({"enc": encoder.state_dict(), "dec": detector.state_dict()}, path)
+
+
+def _write_config(path, checkpoint_path, tokenizer_conversion_multiplier=2):
+    path.write_text(
+        json.dumps(
+            {
+                "algorithm_name": "E2E",
+                "delta": 1.25,
+                "top_k": 4,
+                "window_size": 3,
+                "detection_threshold": 0.5,
+                "checkpoint_path": str(checkpoint_path),
+                "reference_model_name": "unused-in-tests",
+                "reference_tokenizer_name": "unused-in-tests",
+                "tokenizer_conversion_multiplier": tokenizer_conversion_multiplier,
+                "mapper_layers": 2,
+                "hidden_dim": 4,
+                "detector_layers": 1,
+            }
+        )
+    )
+
+
+def _load_watermark(tmp_path, generation_tokenizer=None, reference_tokenizer=None):
+    checkpoint_path = tmp_path / "checkpoint.pth"
+    config_path = tmp_path / "E2E.json"
+    _write_checkpoint(checkpoint_path)
+    _write_config(config_path, checkpoint_path)
+    generation_tokenizer = generation_tokenizer or _Tokenizer()
+    reference_tokenizer = reference_tokenizer or generation_tokenizer
+    model = _Model()
+    transformers_config = TransformersConfig(
+        model=model,
+        tokenizer=generation_tokenizer,
+        vocab_size=8,
+        device="cpu",
+        max_new_tokens=2,
+    )
+    return AutoWatermark.load(
+        "E2E",
+        algorithm_config=str(config_path),
+        transformers_config=transformers_config,
+        reference_model=model,
+        reference_tokenizer=reference_tokenizer,
+    )
+
+
+def test_e2e_is_registered_with_auto_classes():
+    assert config_name_from_alg_name("E2E") == "watermark.e2e.E2EConfig"
+    assert watermark_name_from_alg_name("E2E") == "watermark.e2e.E2E"
+
+
+def test_logits_processor_handles_each_batch_row(tmp_path):
+    watermark = _load_watermark(tmp_path)
+    input_ids = torch.tensor([[1, 2, 3], [3, 2, 1]])
+    scores = torch.tensor([[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]] * 2)
+
+    processed = watermark.logits_processor(input_ids, scores)
+    differences = processed - scores
+
+    assert processed.shape == scores.shape
+    assert torch.count_nonzero(differences[0, :4]) == 0
+    assert torch.count_nonzero(differences[0, 4:]) > 0
+    assert not torch.equal(differences[0], differences[1])
+
+
+def test_generation_detection_and_visualization_use_markllm_interfaces(tmp_path):
+    watermark = _load_watermark(tmp_path)
+
+    generated = watermark.generate_watermarked_text("1 2 3")
+    result = watermark.detect_watermark(generated)
+    visualization = watermark.get_data_for_visualization(generated)
+
+    assert isinstance(watermark, E2E)
+    assert len(generated.split()) == 6
+    assert set(result) == {"is_watermarked", "score"}
+    assert isinstance(result["is_watermarked"], bool)
+    assert math.isfinite(result["score"])
+    assert 0 <= result["score"] <= 1
+    assert len(visualization.decoded_tokens) == 6
+    assert len(visualization.highlight_values) == 6
+    assert all(0 <= value <= 1 for value in visualization.highlight_values)
+
+
+def test_different_tokenizers_use_reference_conversion(tmp_path):
+    watermark = _load_watermark(
+        tmp_path,
+        generation_tokenizer=_Tokenizer("generation"),
+        reference_tokenizer=_Tokenizer("reference"),
+    )
+    input_ids = torch.tensor([[1, 2, 3, 4, 5, 6]])
+    scores = torch.arange(8, dtype=torch.float).unsqueeze(0)
+
+    processed = watermark.logits_processor(input_ids, scores)
+
+    assert watermark.utils.same_tokenizer is False
+    assert watermark.utils.prefix_length == 6
+    assert processed.shape == scores.shape
+    assert not torch.equal(processed, scores)

--- a/test/test_method.py
+++ b/test/test_method.py
@@ -37,7 +37,7 @@ def test_algorithm(algorithm_name):
     assert algorithm_name in ['KGW', 'Unigram', 'SWEET', 'EWD', 'SIR',
                               'XSIR', 'DIP', 'Unbiased', 'UPV', 'TS',
                               'SynthID', 'EXP', 'EXPGumbel', 'EXPEdit',
-                              'ITSEdit', 'PF', 'MorphMark', 'Adaptive', 'KSEMSTAMP','SEMSTAMP', 'IE']
+                              'ITSEdit', 'PF', 'MorphMark', 'Adaptive', 'KSEMSTAMP','SEMSTAMP', 'IE', 'E2E']
 
     # Device
     device = "cuda" if torch.cuda.is_available() else "cpu"

--- a/test/test_visualize.py
+++ b/test/test_visualize.py
@@ -106,7 +106,7 @@ def test_visualization_without_weight(algorithm_name, visualize_type='discrete')
     if visualize_type == 'discrete':
         assert algorithm_name in ['KGW', 'Unigram', 'SWEET', 'UPV', 'SIR', 'XSIR', 'EWD', 'DIP', 'Unbiased']
     else:
-        assert algorithm_name in ['EXP', 'EXPEdit', 'ITSEdit', 'EXPGumbel']
+        assert algorithm_name in ['EXP', 'EXPEdit', 'ITSEdit', 'EXPGumbel', 'E2E']
 
     # Get data for visualization
     watermarked_data, unwatermarked_data = get_data(algorithm_name)

--- a/watermark/auto_config.py
+++ b/watermark/auto_config.py
@@ -45,7 +45,8 @@ CONFIG_MAPPING_NAMES = {
     'Adaptive': 'watermark.adaptive.AdaptiveConfig',
     "KSEMSTAMP": 'watermark.k_semstamp.KSemStampConfig',
     "SEMSTAMP": 'watermark.semstamp.SemStampConfig',
-    "IE": "watermark.ie.IEConfig"
+    "IE": "watermark.ie.IEConfig",
+    "E2E": "watermark.e2e.E2EConfig"
 }
 
 

--- a/watermark/auto_watermark.py
+++ b/watermark/auto_watermark.py
@@ -45,7 +45,8 @@ WATERMARK_MAPPING_NAMES = {
     'Adaptive': 'watermark.adaptive.Adaptive',
     "KSEMSTAMP": 'watermark.k_semstamp.KSemStamp',
     "SEMSTAMP": 'watermark.semstamp.SemStamp',
-    "IE": "watermark.ie.IE"
+    "IE": "watermark.ie.IE",
+    "E2E": "watermark.e2e.E2E"
 }
 
 

--- a/watermark/e2e/LICENSE
+++ b/watermark/e2e/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Kahim Wong
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/watermark/e2e/README.md
+++ b/watermark/e2e/README.md
@@ -1,0 +1,23 @@
+# E2E-LLM-Watermark model files
+
+This integration uses the encoder/detector checkpoint released by the
+official [E2E-LLM-Watermark repository](https://github.com/KahimWong/E2E-LLM-Watermark).
+
+Download `35000.pth` and place it at the path configured by
+`checkpoint_path` in `config/E2E.json`:
+
+```bash
+mkdir -p watermark/e2e/model
+wget -O watermark/e2e/model/35000.pth \
+  https://github.com/KahimWong/E2E-LLM-Watermark/raw/master/ckpt/35000.pth
+```
+
+Expected SHA-256:
+
+```text
+3dc85de9d81fda064de179731e57c6c7c9d3b3d868ebe7a616edc08e23686174
+```
+
+The released checkpoint was trained with `facebook/opt-1.3b` embeddings.
+Generation can use a different Hugging Face causal language model; candidate
+text is converted through the configured reference tokenizer when necessary.

--- a/watermark/e2e/__init__.py
+++ b/watermark/e2e/__init__.py
@@ -1,0 +1,6 @@
+# Copyright 2026 THU-BPM MarkLLM.
+# Licensed under the Apache License, Version 2.0.
+
+from .e2e import E2E, E2EConfig
+
+__all__ = ["E2E", "E2EConfig"]

--- a/watermark/e2e/e2e.py
+++ b/watermark/e2e/e2e.py
@@ -1,0 +1,296 @@
+# Copyright 2025 Kahim Wong.
+# Copyright 2026 THU-BPM MarkLLM.
+#
+# Adapted from E2E-LLM-Watermark, released under the MIT License. See
+# watermark/e2e/LICENSE for the original license and attribution.
+
+"""MarkLLM integration of the E2E-LLM-Watermark algorithm."""
+
+from functools import partial
+from pathlib import Path
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from transformers import LogitsProcessor, LogitsProcessorList
+
+from exceptions.exceptions import AlgorithmNameMismatchError
+from utils.transformers_config import TransformersConfig
+from visualize.data_for_visualization import DataForVisualization
+from watermark.base import BaseConfig, BaseWatermark
+
+from .model import E2EDetector, E2EEncoder
+
+
+class E2EConfig(BaseConfig):
+    """Load and validate the E2E algorithm configuration."""
+
+    def initialize_parameters(self) -> None:
+        if self.config_dict["algorithm_name"] != self.algorithm_name:
+            raise AlgorithmNameMismatchError(
+                self.algorithm_name, self.config_dict["algorithm_name"]
+            )
+
+        self.delta = float(self.config_dict["delta"])
+        self.top_k = int(self.config_dict["top_k"])
+        self.window_size = int(self.config_dict["window_size"])
+        self.detection_threshold = float(self.config_dict["detection_threshold"])
+        self.checkpoint_path = self.config_dict["checkpoint_path"]
+        self.reference_model_name = self.config_dict["reference_model_name"]
+        self.reference_tokenizer_name = self.config_dict.get(
+            "reference_tokenizer_name", self.reference_model_name
+        )
+        self.tokenizer_conversion_multiplier = int(
+            self.config_dict.get("tokenizer_conversion_multiplier", 3)
+        )
+        self.mapper_layers = int(self.config_dict.get("mapper_layers", 5))
+        self.hidden_dim = int(self.config_dict.get("hidden_dim", 64))
+        self.detector_layers = int(self.config_dict.get("detector_layers", 3))
+        self.reference_model = self.config_dict.get("reference_model")
+        self.reference_tokenizer = self.config_dict.get("reference_tokenizer")
+
+        if self.top_k < 2:
+            raise ValueError("E2E top_k must be at least 2")
+        if self.window_size < 1:
+            raise ValueError("E2E window_size must be positive")
+        if not 0 <= self.detection_threshold <= 1:
+            raise ValueError("E2E detection_threshold must be in [0, 1]")
+        if not Path(self.checkpoint_path).is_file():
+            raise FileNotFoundError(
+                f"E2E checkpoint not found at {self.checkpoint_path}. "
+                "See watermark/e2e/README.md for download instructions."
+            )
+
+    @property
+    def algorithm_name(self) -> str:
+        return "E2E"
+
+
+class E2EUtils:
+    """Shared model loading, token conversion, and scoring utilities."""
+
+    def __init__(self, config: E2EConfig) -> None:
+        self.config = config
+        self.reference_tokenizer = (
+            config.reference_tokenizer
+            or AutoTokenizer.from_pretrained(config.reference_tokenizer_name)
+        )
+        self.same_tokenizer = self._tokenizers_match(
+            config.generation_tokenizer, self.reference_tokenizer
+        )
+        self.prefix_length = config.window_size
+        if not self.same_tokenizer:
+            self.prefix_length *= config.tokenizer_conversion_multiplier
+
+        try:
+            checkpoint = torch.load(
+                config.checkpoint_path,
+                map_location=config.device,
+                weights_only=True,
+            )
+        except TypeError:
+            checkpoint = torch.load(config.checkpoint_path, map_location=config.device)
+        self.input_dim = checkpoint["enc"]["mapper.0.weight"].shape[1]
+        self.reference_embeddings = self._load_reference_embeddings()
+        if self.reference_embeddings.embedding_dim != self.input_dim:
+            raise ValueError(
+                "E2E reference embedding dimension does not match the checkpoint: "
+                f"expected {self.input_dim}, got "
+                f"{self.reference_embeddings.embedding_dim}"
+            )
+        self.encoder = E2EEncoder(
+            input_dim=self.input_dim,
+            mapper_layers=config.mapper_layers,
+            window_size=config.window_size,
+            hidden_dim=config.hidden_dim,
+        ).to(config.device)
+        self.detector = E2EDetector(
+            input_dim=self.input_dim,
+            hidden_dim=config.hidden_dim,
+            num_layers=config.detector_layers,
+        ).to(config.device)
+        self.encoder.load_state_dict(checkpoint["enc"])
+        self.detector.load_state_dict(checkpoint["dec"])
+        self.encoder.eval()
+        self.detector.eval()
+
+    def _load_reference_embeddings(self) -> torch.nn.Embedding:
+        generation_embeddings = self.config.generation_model.get_input_embeddings()
+        if (
+            self.same_tokenizer
+            and generation_embeddings.embedding_dim == self.input_dim
+        ):
+            embeddings = generation_embeddings
+            embeddings.requires_grad_(False)
+            return embeddings
+
+        reference_model = self.config.reference_model
+        if reference_model is None:
+            reference_model = AutoModelForCausalLM.from_pretrained(
+                self.config.reference_model_name,
+                torch_dtype=torch.float16,
+            )
+        embeddings = reference_model.get_input_embeddings().to(self.config.device)
+        embeddings.requires_grad_(False)
+        return embeddings
+
+    @staticmethod
+    def _tokenizers_match(generation_tokenizer, reference_tokenizer) -> bool:
+        try:
+            return generation_tokenizer.get_vocab() == reference_tokenizer.get_vocab()
+        except (AttributeError, NotImplementedError):
+            return (
+                len(generation_tokenizer) == len(reference_tokenizer)
+                and generation_tokenizer.__class__ is reference_tokenizer.__class__
+            )
+
+    def _convert_candidate_ids(self, candidate_sequences: torch.Tensor) -> torch.Tensor:
+        """Convert generation-tokenizer candidates to reference-tokenizer ids."""
+        batch_size, candidate_count, _ = candidate_sequences.shape
+        converted = []
+        pad_token_id = self.reference_tokenizer.pad_token_id
+        if pad_token_id is None:
+            pad_token_id = self.reference_tokenizer.eos_token_id
+        if pad_token_id is None:
+            raise ValueError("The E2E reference tokenizer needs a pad or EOS token")
+
+        for sequence in candidate_sequences.reshape(-1, candidate_sequences.shape[-1]):
+            text = self.config.generation_tokenizer.decode(
+                sequence.tolist(), skip_special_tokens=True
+            )
+            token_ids = self.reference_tokenizer(text, add_special_tokens=False)[
+                "input_ids"
+            ][-self.config.window_size :]
+            token_ids = [pad_token_id] * (
+                self.config.window_size - len(token_ids)
+            ) + token_ids
+            converted.append(token_ids)
+        return torch.tensor(
+            converted, device=self.config.device, dtype=torch.long
+        ).reshape(batch_size, candidate_count, self.config.window_size)
+
+    def candidate_embeddings(
+        self, input_ids: torch.LongTensor, candidate_ids: torch.LongTensor
+    ) -> torch.Tensor:
+        """Build contextual reference embeddings for every top-k candidate."""
+        context_length = self.prefix_length - 1
+        previous_ids = (
+            input_ids[:, -context_length:] if context_length else input_ids[:, :0]
+        )
+        previous_ids = previous_ids[:, None, :].expand(-1, candidate_ids.shape[1], -1)
+        candidate_sequences = torch.cat(
+            [previous_ids, candidate_ids.unsqueeze(-1)], dim=-1
+        )
+        if self.same_tokenizer:
+            reference_ids = candidate_sequences
+        else:
+            reference_ids = self._convert_candidate_ids(candidate_sequences)
+        return self.reference_embeddings(reference_ids).float()
+
+    def encode_text(self, text: str) -> tuple[torch.LongTensor, torch.Tensor]:
+        encoding = self.reference_tokenizer(
+            text, return_tensors="pt", add_special_tokens=False
+        )
+        input_ids = encoding["input_ids"][0].to(self.config.device)
+        if input_ids.numel() == 0:
+            raise ValueError("E2E cannot detect a watermark in empty text")
+        embeddings = self.reference_embeddings(input_ids.unsqueeze(0)).float()
+        return input_ids, embeddings
+
+    def score_text(self, text: str) -> float:
+        _, embeddings = self.encode_text(text)
+        with torch.inference_mode():
+            probability = torch.sigmoid(self.detector(embeddings)).squeeze()
+        return float(probability.item())
+
+    def score_prefixes(self, text: str) -> tuple[torch.LongTensor, list[float]]:
+        input_ids, embeddings = self.encode_text(text)
+        with torch.inference_mode():
+            probabilities = (
+                torch.sigmoid(self.detector(embeddings, return_all=True))
+                .squeeze(0)
+                .squeeze(-1)
+            )
+        return input_ids, probabilities.cpu().tolist()
+
+
+class E2ELogitsProcessor(LogitsProcessor):
+    """Apply learned, centered perturbations to the top-k token logits."""
+
+    def __init__(self, config: E2EConfig, utils: E2EUtils) -> None:
+        self.config = config
+        self.utils = utils
+
+    def __call__(
+        self, input_ids: torch.LongTensor, scores: torch.FloatTensor
+    ) -> torch.FloatTensor:
+        if input_ids.shape[-1] < self.utils.prefix_length:
+            return scores
+
+        candidate_count = min(self.config.top_k, scores.shape[-1])
+        candidate_ids = torch.topk(scores, candidate_count, dim=-1).indices
+        embeddings = self.utils.candidate_embeddings(input_ids, candidate_ids)
+        with torch.inference_mode():
+            candidate_bias = self.utils.encoder(embeddings)
+        perturbation = torch.zeros_like(scores)
+        perturbation.scatter_add_(
+            1,
+            candidate_ids,
+            self.config.delta * candidate_bias.to(scores.dtype),
+        )
+        return scores + perturbation
+
+
+class E2E(BaseWatermark):
+    """End-to-end learned logits watermark and neural detector."""
+
+    def __init__(
+        self,
+        algorithm_config: str | E2EConfig,
+        transformers_config: TransformersConfig | None = None,
+        *args,
+        **kwargs,
+    ) -> None:
+        if isinstance(algorithm_config, str):
+            self.config = E2EConfig(algorithm_config, transformers_config, **kwargs)
+        elif isinstance(algorithm_config, E2EConfig):
+            self.config = algorithm_config
+        else:
+            raise TypeError(
+                "algorithm_config must be either a path string or an E2EConfig instance"
+            )
+        self.utils = E2EUtils(self.config)
+        self.logits_processor = E2ELogitsProcessor(self.config, self.utils)
+
+    def generate_watermarked_text(self, prompt: str, *args, **kwargs) -> str:
+        generate_with_watermark = partial(
+            self.config.generation_model.generate,
+            logits_processor=LogitsProcessorList([self.logits_processor]),
+            **self.config.gen_kwargs,
+        )
+        encoded_prompt = self.config.generation_tokenizer(
+            prompt, return_tensors="pt", add_special_tokens=True
+        ).to(self.config.device)
+        encoded_text = generate_with_watermark(**encoded_prompt)
+        return self.config.generation_tokenizer.batch_decode(
+            encoded_text, skip_special_tokens=True
+        )[0]
+
+    def detect_watermark(self, text: str, return_dict: bool = True, *args, **kwargs):
+        score = self.utils.score_text(text)
+        is_watermarked = bool(score > self.config.detection_threshold)
+        if return_dict:
+            return {"is_watermarked": is_watermarked, "score": score}
+        return is_watermarked, score
+
+    def get_data_for_visualization(
+        self, text: str, *args, **kwargs
+    ) -> DataForVisualization:
+        input_ids, probabilities = self.utils.score_prefixes(text)
+        decoded_tokens = [
+            self.reference_tokenizer.decode(int(token_id)) for token_id in input_ids
+        ]
+        return DataForVisualization(decoded_tokens, probabilities)
+
+    @property
+    def reference_tokenizer(self):
+        return self.utils.reference_tokenizer

--- a/watermark/e2e/model.py
+++ b/watermark/e2e/model.py
@@ -1,0 +1,67 @@
+# Copyright 2025 Kahim Wong.
+# Copyright 2026 THU-BPM MarkLLM.
+#
+# The model architecture is adapted from E2E-LLM-Watermark, released under
+# the MIT License. See watermark/e2e/LICENSE for the original license.
+
+"""Neural encoder and detector used by E2E-LLM-Watermark."""
+
+import torch
+from torch import nn
+
+
+class E2EEncoder(nn.Module):
+    """Score top-k generation candidates from their contextual embeddings."""
+
+    def __init__(
+        self,
+        input_dim: int,
+        mapper_layers: int = 5,
+        window_size: int = 10,
+        hidden_dim: int = 64,
+    ) -> None:
+        super().__init__()
+        self.mapper = nn.ModuleList([nn.Linear(input_dim, hidden_dim), nn.ReLU()])
+        for _ in range(mapper_layers - 1):
+            self.mapper.extend([nn.Linear(hidden_dim, hidden_dim), nn.ReLU()])
+        self.mapper.append(nn.Linear(hidden_dim, hidden_dim))
+
+        self.fc1 = nn.Linear(window_size * hidden_dim, hidden_dim)
+        self.relu = nn.ReLU()
+        self.fc2 = nn.Linear(hidden_dim, 1)
+
+    def forward(self, embeddings: torch.Tensor) -> torch.Tensor:
+        """Return a centered score in ``[-1, 1]`` for every candidate."""
+        batch_size, candidate_count, _, _ = embeddings.shape
+        for layer in self.mapper:
+            embeddings = layer(embeddings)
+        embeddings = embeddings.reshape(batch_size, candidate_count, -1)
+        logits = self.fc2(self.relu(self.fc1(embeddings))).squeeze(-1)
+        centered_logits = logits - logits.mean(dim=1, keepdim=True)
+        return torch.tanh(1000 * centered_logits)
+
+
+class E2EDetector(nn.Module):
+    """Detect the learned watermark from a sequence of token embeddings."""
+
+    def __init__(
+        self,
+        input_dim: int,
+        hidden_dim: int = 64,
+        num_classes: int = 1,
+        num_layers: int = 3,
+    ) -> None:
+        super().__init__()
+        self.lstm = nn.LSTM(input_dim, hidden_dim, num_layers, batch_first=True)
+        self.fc_2 = nn.Linear(hidden_dim, hidden_dim)
+        self.relu = nn.ReLU()
+        self.fc_1 = nn.Linear(hidden_dim, num_classes)
+
+    def forward(
+        self, embeddings: torch.Tensor, return_all: bool = False
+    ) -> torch.Tensor:
+        """Return the final logit, or one logit per prefix for visualization."""
+        hidden_states, _ = self.lstm(embeddings)
+        if not return_all:
+            hidden_states = hidden_states[:, -1, :]
+        return self.fc_1(self.relu(self.fc_2(hidden_states)))


### PR DESCRIPTION
## Summary

- integrate the ICML 2025 E2E-LLM-Watermark learned top-k logits encoder and neural detector with the MarkLLM `BaseWatermark` interface
- add `config/E2E.json`, automatic registration, same/different-tokenizer support, batched logits processing, and CPU-compatible model loading
- expose detector prefix probabilities through MarkLLM continuous visualization
- document the official checkpoint download and SHA-256, and retain the upstream MIT attribution

## Validation

- `pytest -q test/test_e2e.py` — 4 passed
- real generation/detection smoke test using `facebook/opt-125m`, the official `35000.pth` checkpoint, and the required OPT-1.3B reference embeddings
- MarkLLM detection pipelines on two C4 samples:
  - watermarked scores: `0.9996388`, `0.9995152`
  - natural-text scores: `0.0392422`, `0.0007959`
  - dynamic-threshold TPR/TNR/F1/accuracy: `1.0/1.0/1.0/1.0`
- generated and inspected a continuous visualization of per-prefix detector probabilities

The two-sample pipeline run is a smoke test rather than a reproduction of the paper benchmark. Model weights are not committed; the package README documents how to obtain the official checkpoint.