### PR TITLE
Add SimMark sentence-level watermark

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ MarkLLM is an open-source toolkit developed to facilitate the research and appli
   | EXP-Edit           | TMLR 2024 | [\[2307.15593\] Robust Distortion-free Watermarks for Language Models (arxiv.org)](https://arxiv.org/abs/2307.15593)                                                           |
   | ITS-Edit           | TMLR 2024 | [\[2307.15593\] Robust Distortion-free Watermarks for Language Models (arxiv.org)](https://arxiv.org/abs/2307.15593)                                                           |
   | IE           | Arxiv Preprint | [\[2505.14112\] Invisible Entropy: Towards Safe and Efficient Low-Entropy LLM Watermarking (arxiv.org)](https://arxiv.org/abs/2505.14112)                                                           |
+  | SimMark | EMNLP 2025 | [\[2502.02787\] SimMark: A Robust Sentence-Level Similarity-Based Watermarking Algorithm for Large Language Models](https://arxiv.org/abs/2502.02787) |
 - **Visualization Solutions:** The toolkit includes custom visualization tools that enable clear and insightful views into how different watermarking algorithms operate under various scenarios. These visualizations help demystify the algorithms' mechanisms, making them more understandable for users.
 
   <img src="images\mechanism_visualization.png" alt="mechanism_visualization" style="zoom:35%;" />

--- a/config/SimMark.json
+++ b/config/SimMark.json
@@ -1,0 +1,13 @@
+{
+    "algorithm_name": "SimMark",
+    "embedding_model_name": "hkunlp/instructor-large",
+    "embedding_prompt": "Represent the sentence for cosine similarity:",
+    "interval_low": 0.68,
+    "interval_high": 0.76,
+    "expected_valid_fraction": 0.1,
+    "softness": 250.0,
+    "z_threshold": 2.33,
+    "max_trials": 100,
+    "candidate_max_new_tokens": 64,
+    "ensure_sentence_punctuation": true
+}

--- a/test/test_method.py
+++ b/test/test_method.py
@@ -37,7 +37,7 @@ def test_algorithm(algorithm_name):
     assert algorithm_name in ['KGW', 'Unigram', 'SWEET', 'EWD', 'SIR',
                               'XSIR', 'DIP', 'Unbiased', 'UPV', 'TS',
                               'SynthID', 'EXP', 'EXPGumbel', 'EXPEdit',
-                              'ITSEdit', 'PF', 'MorphMark', 'Adaptive', 'KSEMSTAMP','SEMSTAMP', 'IE']
+                              'ITSEdit', 'PF', 'MorphMark', 'Adaptive', 'KSEMSTAMP','SEMSTAMP', 'IE', 'SimMark']
 
     # Device
     device = "cuda" if torch.cuda.is_available() else "cpu"

--- a/test/test_simmark.py
+++ b/test/test_simmark.py
@@ -1,0 +1,190 @@
+# Copyright 2026 THU-BPM MarkLLM.
+# Licensed under the Apache License, Version 2.0.
+
+import json
+import math
+
+import torch
+
+from utils.transformers_config import TransformersConfig
+from watermark.auto_config import config_name_from_alg_name
+from watermark.auto_watermark import AutoWatermark, watermark_name_from_alg_name
+from watermark.simmark import SimMark
+from watermark.simmark.simmark import split_sentences
+
+
+class _Encoding(dict):
+    def to(self, device):
+        return _Encoding({key: value.to(device) for key, value in self.items()})
+
+
+class _Tokenizer:
+    eos_token_id = 0
+    pad_token_id = 0
+
+    def __len__(self):
+        return 16
+
+    def encode(self, text, add_special_tokens=False):
+        pieces = text.replace(".", " . ").split()
+        token_ids = [15 if piece == "." else int(piece) % 15 for piece in pieces]
+        if add_special_tokens:
+            token_ids.insert(0, 0)
+        return token_ids
+
+    def __call__(self, text, return_tensors=None, add_special_tokens=False):
+        token_ids = self.encode(text, add_special_tokens)
+        if return_tensors == "pt":
+            return _Encoding(input_ids=torch.tensor([token_ids], dtype=torch.long))
+        return {"input_ids": token_ids}
+
+    def decode(self, token_ids, skip_special_tokens=False):
+        if isinstance(token_ids, int):
+            token_ids = [token_ids]
+        pieces = []
+        for token_id in token_ids:
+            token_id = int(token_id)
+            if skip_special_tokens and token_id == 0:
+                continue
+            pieces.append("." if token_id == 15 else str(token_id))
+        return " ".join(pieces)
+
+    def batch_decode(self, sequences, skip_special_tokens=False):
+        return [self.decode(sequence, skip_special_tokens) for sequence in sequences]
+
+
+class _Model(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.anchor = torch.nn.Parameter(torch.zeros(1))
+        self.calls = 0
+
+    def generate(self, input_ids, **kwargs):
+        self.calls += 1
+        candidate = torch.tensor([[3, 4, 15]], device=input_ids.device)
+        return torch.cat([input_ids, candidate], dim=1)
+
+
+class _Embedder:
+    def __init__(self):
+        self.calls = []
+
+    def encode(
+        self,
+        sentences,
+        prompt=None,
+        convert_to_tensor=True,
+        normalize_embeddings=True,
+        show_progress_bar=False,
+    ):
+        self.calls.append(sentences)
+        return torch.tensor([[1.0, 0.0] for _ in sentences])
+
+
+def _load_watermark(tmp_path):
+    config_path = tmp_path / "SimMark.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "algorithm_name": "SimMark",
+                "embedding_model_name": "unused-in-tests",
+                "embedding_prompt": "Represent the sentence:",
+                "interval_low": 0.9,
+                "interval_high": 1.0,
+                "expected_valid_fraction": 0.25,
+                "softness": 10.0,
+                "z_threshold": 2.0,
+                "max_trials": 3,
+                "candidate_max_new_tokens": 4,
+                "ensure_sentence_punctuation": True,
+            }
+        )
+    )
+    model = _Model()
+    tokenizer = _Tokenizer()
+    transformers_config = TransformersConfig(
+        model=model,
+        tokenizer=tokenizer,
+        vocab_size=16,
+        device="cpu",
+        max_new_tokens=6,
+        do_sample=True,
+    )
+    watermark = AutoWatermark.load(
+        "SimMark",
+        algorithm_config=str(config_path),
+        transformers_config=transformers_config,
+        embedding_model=_Embedder(),
+    )
+    return watermark, model
+
+
+def test_simmark_is_registered_with_auto_classes():
+    assert config_name_from_alg_name("SimMark") == ("watermark.simmark.SimMarkConfig")
+    assert watermark_name_from_alg_name("SimMark") == ("watermark.simmark.SimMark")
+
+
+def test_sentence_splitter_and_soft_interval_score(tmp_path):
+    watermark, _ = _load_watermark(tmp_path)
+
+    assert split_sentences("First sentence. Second sentence!") == [
+        "First sentence.",
+        "Second sentence!",
+    ]
+    assert watermark.utils.soft_score(0.95) == 1.0
+    assert math.isclose(watermark.utils.soft_score(0.8), math.exp(-1.0))
+
+
+def test_soft_z_detection_scores_sentence_pairs(tmp_path):
+    watermark, _ = _load_watermark(tmp_path)
+
+    result = watermark.utils.score_text(
+        "First sentence. Second sentence. Third sentence."
+    )
+
+    expected = (2 - 0.25 * 2) / math.sqrt(2 * 0.25 * 0.75 + 1e-12)
+    assert result.similarities == [1.0, 1.0]
+    assert result.soft_scores == [1.0, 1.0]
+    assert math.isclose(result.z_score, expected)
+    assert watermark.utils.embedder.calls[-1] == [
+        "First sentence.",
+        " Second sentence.",
+        " Third sentence.",
+    ]
+
+
+def test_generation_detection_and_visualization_use_markllm_interfaces(tmp_path):
+    watermark, model = _load_watermark(tmp_path)
+
+    generated = watermark.generate_watermarked_text("1 2 .")
+    detection = watermark.detect_watermark(generated)
+    visualization = watermark.get_data_for_visualization(generated)
+
+    assert isinstance(watermark, SimMark)
+    assert model.calls == 2
+    assert len(split_sentences(generated)) == 3
+    assert set(detection) == {"is_watermarked", "score"}
+    assert detection["is_watermarked"] is True
+    assert detection["score"] > 2.0
+    assert visualization.highlight_values == [
+        None,
+        None,
+        None,
+        1.0,
+        1.0,
+        1.0,
+        1.0,
+        1.0,
+        1.0,
+    ]
+    assert visualization.decoded_tokens == [
+        "1 ",
+        "2 ",
+        ".",
+        "3 ",
+        "4 ",
+        ".",
+        "3 ",
+        "4 ",
+        ".",
+    ]

--- a/test/test_visualize.py
+++ b/test/test_visualize.py
@@ -106,7 +106,7 @@ def test_visualization_without_weight(algorithm_name, visualize_type='discrete')
     if visualize_type == 'discrete':
         assert algorithm_name in ['KGW', 'Unigram', 'SWEET', 'UPV', 'SIR', 'XSIR', 'EWD', 'DIP', 'Unbiased']
     else:
-        assert algorithm_name in ['EXP', 'EXPEdit', 'ITSEdit', 'EXPGumbel']
+        assert algorithm_name in ['EXP', 'EXPEdit', 'ITSEdit', 'EXPGumbel', 'SimMark']
 
     # Get data for visualization
     watermarked_data, unwatermarked_data = get_data(algorithm_name)

--- a/watermark/auto_config.py
+++ b/watermark/auto_config.py
@@ -45,7 +45,8 @@ CONFIG_MAPPING_NAMES = {
     'Adaptive': 'watermark.adaptive.AdaptiveConfig',
     "KSEMSTAMP": 'watermark.k_semstamp.KSemStampConfig',
     "SEMSTAMP": 'watermark.semstamp.SemStampConfig',
-    "IE": "watermark.ie.IEConfig"
+    "IE": "watermark.ie.IEConfig",
+    "SimMark": "watermark.simmark.SimMarkConfig"
 }
 
 

--- a/watermark/auto_watermark.py
+++ b/watermark/auto_watermark.py
@@ -45,7 +45,8 @@ WATERMARK_MAPPING_NAMES = {
     'Adaptive': 'watermark.adaptive.Adaptive',
     "KSEMSTAMP": 'watermark.k_semstamp.KSemStamp',
     "SEMSTAMP": 'watermark.semstamp.SemStamp',
-    "IE": "watermark.ie.IE"
+    "IE": "watermark.ie.IE",
+    "SimMark": "watermark.simmark.SimMark"
 }
 
 

--- a/watermark/simmark/LICENSE
+++ b/watermark/simmark/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Amirhossein Dabiriaghdam
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/watermark/simmark/README.md
+++ b/watermark/simmark/README.md
@@ -1,0 +1,19 @@
+# SimMark integration
+
+This module adapts the cosine-similarity variant of
+[SimMark](https://github.com/DabiriAghdam/SimMark) to MarkLLM.
+
+Generation proceeds one sentence at a time. Candidate sentences are generated
+with the configured causal language model and accepted when their embedding
+similarity with the previous sentence falls in the configured interval. The
+detector applies SimMark's soft counting function and returns its z-score.
+
+The default `config/SimMark.json` follows the official RealNews/C4 cosine
+setting (`hkunlp/instructor-large`, interval `[0.68, 0.76]`, softness `K=250`).
+`expected_valid_fraction` is the empirical probability that a human sentence
+pair falls inside the interval. The upstream evaluation estimates it on a
+domain-matched human calibration set; users should likewise recalibrate this
+field when changing the domain, embedder, or interval.
+
+The cosine variant does not require the optional PCA checkpoint used by the
+paper's Euclidean variant.

--- a/watermark/simmark/__init__.py
+++ b/watermark/simmark/__init__.py
@@ -1,0 +1,6 @@
+# Copyright 2026 THU-BPM MarkLLM.
+# Licensed under the Apache License, Version 2.0.
+
+from .simmark import SimMark, SimMarkConfig
+
+__all__ = ["SimMark", "SimMarkConfig"]

--- a/watermark/simmark/simmark.py
+++ b/watermark/simmark/simmark.py
@@ -1,0 +1,305 @@
+# Copyright 2025 Amirhossein Dabiriaghdam.
+# Copyright 2026 THU-BPM MarkLLM.
+#
+# Adapted from SimMark, released under the MIT License. See
+# watermark/simmark/LICENSE for the original license and attribution.
+
+"""MarkLLM integration of sentence-level SimMark watermarking."""
+
+from dataclasses import dataclass
+from functools import partial
+import math
+import re
+
+import torch
+import torch.nn.functional as F
+from nltk.tokenize import sent_tokenize
+from sentence_transformers import SentenceTransformer
+from transformers import StoppingCriteria, StoppingCriteriaList
+
+from exceptions.exceptions import AlgorithmNameMismatchError
+from utils.transformers_config import TransformersConfig
+from visualize.data_for_visualization import DataForVisualization
+from watermark.base import BaseConfig, BaseWatermark
+
+
+_SENTENCE_BOUNDARY = re.compile(r"(?<=[.!?])\s+")
+_VISUALIZATION_TOKEN = re.compile(r"\S+\s*")
+
+
+def split_sentences(text: str) -> list[str]:
+    """Split text with Punkt when available and a no-download fallback."""
+    text = text.strip()
+    if not text:
+        return []
+    try:
+        sentences = sent_tokenize(text)
+    except LookupError:
+        sentences = _SENTENCE_BOUNDARY.split(text)
+    return [sentence.strip() for sentence in sentences if sentence.strip()]
+
+
+class SimMarkConfig(BaseConfig):
+    """Load SimMark generation, embedding, and soft-z parameters."""
+
+    def initialize_parameters(self) -> None:
+        if self.config_dict["algorithm_name"] != self.algorithm_name:
+            raise AlgorithmNameMismatchError(
+                self.algorithm_name, self.config_dict["algorithm_name"]
+            )
+
+        self.embedding_model_name = self.config_dict["embedding_model_name"]
+        self.embedding_prompt = self.config_dict.get(
+            "embedding_prompt", "Represent the sentence for cosine similarity:"
+        )
+        self.interval_low = float(self.config_dict["interval_low"])
+        self.interval_high = float(self.config_dict["interval_high"])
+        self.expected_valid_fraction = float(
+            self.config_dict["expected_valid_fraction"]
+        )
+        self.softness = float(self.config_dict.get("softness", 250.0))
+        self.z_threshold = float(self.config_dict.get("z_threshold", 2.33))
+        self.max_trials = int(self.config_dict.get("max_trials", 100))
+        self.candidate_max_new_tokens = int(
+            self.config_dict.get("candidate_max_new_tokens", 64)
+        )
+        self.ensure_sentence_punctuation = bool(
+            self.config_dict.get("ensure_sentence_punctuation", True)
+        )
+        self.embedding_model = self.config_dict.get("embedding_model")
+
+        if not -1 <= self.interval_low < self.interval_high <= 1:
+            raise ValueError("SimMark cosine interval must lie within [-1, 1]")
+        if not 0 < self.expected_valid_fraction < 1:
+            raise ValueError("SimMark expected_valid_fraction must be in (0, 1)")
+        if self.softness <= 0:
+            raise ValueError("SimMark softness must be positive")
+        if self.max_trials < 1:
+            raise ValueError("SimMark max_trials must be positive")
+        if self.candidate_max_new_tokens < 1:
+            raise ValueError("SimMark candidate_max_new_tokens must be positive")
+
+    @property
+    def algorithm_name(self) -> str:
+        return "SimMark"
+
+
+@dataclass
+class SimMarkSequenceScore:
+    """Sentence similarities, soft evidence, and aggregate z-score."""
+
+    z_score: float
+    similarities: list[float]
+    soft_scores: list[float]
+
+
+class _CandidateSentenceCriteria(StoppingCriteria):
+    """Stop after a complete sentence and the beginning of the next one."""
+
+    def __init__(self, tokenizer, prompt_length: int) -> None:
+        self.tokenizer = tokenizer
+        self.prompt_length = prompt_length
+
+    def __call__(
+        self,
+        input_ids: torch.LongTensor,
+        scores: torch.FloatTensor,
+        **kwargs,
+    ) -> bool:
+        if input_ids.shape[0] != 1:
+            raise ValueError(
+                "SimMark sentence rejection sampling requires batch size 1"
+            )
+        candidate = self.tokenizer.decode(
+            input_ids[0, self.prompt_length :], skip_special_tokens=True
+        )
+        return len(split_sentences(candidate)) > 1
+
+
+class SimMarkUtils:
+    """Sentence embedding, rejection, and soft-z detection helpers."""
+
+    def __init__(self, config: SimMarkConfig) -> None:
+        self.config = config
+        self.embedder = config.embedding_model or SentenceTransformer(
+            config.embedding_model_name, device=config.device
+        )
+
+    def _encode_sentences(self, sentences: list[str]) -> torch.Tensor:
+        if not sentences:
+            return torch.empty((0, 0))
+        encode = partial(
+            self.embedder.encode,
+            convert_to_tensor=True,
+            normalize_embeddings=True,
+            show_progress_bar=False,
+        )
+        try:
+            embeddings = encode(sentences, prompt=self.config.embedding_prompt)
+        except TypeError:
+            embeddings = encode(sentences)
+        if not isinstance(embeddings, torch.Tensor):
+            embeddings = torch.as_tensor(embeddings)
+        return embeddings.float()
+
+    def similarity(self, previous_sentence: str, candidate_sentence: str) -> float:
+        embeddings = self._encode_sentences([previous_sentence, candidate_sentence])
+        return float(F.cosine_similarity(embeddings[0], embeddings[1], dim=0).item())
+
+    def in_interval(self, similarity: float) -> bool:
+        return self.config.interval_low <= similarity <= self.config.interval_high
+
+    def soft_score(self, similarity: float) -> float:
+        if self.in_interval(similarity):
+            return 1.0
+        distance = min(
+            abs(similarity - self.config.interval_low),
+            abs(similarity - self.config.interval_high),
+        )
+        return math.exp(-self.config.softness * distance)
+
+    def score_text(self, text: str) -> SimMarkSequenceScore:
+        sentences = split_sentences(text)
+        if len(sentences) < 2:
+            return SimMarkSequenceScore(0.0, [], [])
+        # SimMark's reference detector preserves the whitespace before every
+        # sentence except the first one when computing its embeddings.
+        embedding_sentences = [sentences[0], *(f" {item}" for item in sentences[1:])]
+        embeddings = self._encode_sentences(embedding_sentences)
+        similarities = (
+            F.cosine_similarity(embeddings[:-1], embeddings[1:], dim=1).cpu().tolist()
+        )
+        soft_scores = [self.soft_score(value) for value in similarities]
+        test_count = len(soft_scores)
+        gamma = self.config.expected_valid_fraction
+        numerator = sum(soft_scores) - gamma * test_count
+        denominator = math.sqrt(test_count * gamma * (1 - gamma) + 1e-12)
+        return SimMarkSequenceScore(
+            numerator / denominator,
+            similarities,
+            soft_scores,
+        )
+
+    def _generate_candidate(self, text: str, remaining_tokens: int) -> str:
+        tokenizer = self.config.generation_tokenizer
+        encoding = tokenizer(text, return_tensors="pt", add_special_tokens=True).to(
+            self.config.device
+        )
+        prompt_length = encoding["input_ids"].shape[1]
+        generation_kwargs = dict(self.config.gen_kwargs)
+        for key in (
+            "max_length",
+            "min_length",
+            "max_new_tokens",
+            "min_new_tokens",
+            "stopping_criteria",
+        ):
+            generation_kwargs.pop(key, None)
+        generation_kwargs.setdefault("do_sample", True)
+        generation_kwargs["max_new_tokens"] = min(
+            self.config.candidate_max_new_tokens, remaining_tokens
+        )
+        generation_kwargs["stopping_criteria"] = StoppingCriteriaList(
+            [_CandidateSentenceCriteria(tokenizer, prompt_length)]
+        )
+        with torch.inference_mode():
+            output = self.config.generation_model.generate(
+                **encoding, **generation_kwargs
+            )
+        sequences = output.sequences if hasattr(output, "sequences") else output
+        candidate = tokenizer.decode(
+            sequences[0, prompt_length:], skip_special_tokens=True
+        ).strip()
+        sentences = split_sentences(candidate)
+        if sentences:
+            candidate = sentences[0]
+        if (
+            candidate
+            and self.config.ensure_sentence_punctuation
+            and candidate[-1] not in ".!?"
+        ):
+            candidate += "."
+        return candidate
+
+    def generate(self, prompt: str) -> str:
+        """Generate sentence candidates until they satisfy SimMark's interval."""
+        tokenizer = self.config.generation_tokenizer
+        initial_length = len(tokenizer(prompt, add_special_tokens=True)["input_ids"])
+        max_new_tokens = int(self.config.gen_kwargs.get("max_new_tokens", 200))
+        text = prompt.strip()
+        previous_sentences = split_sentences(text)
+        previous_sentence = previous_sentences[-1] if previous_sentences else text
+
+        while True:
+            current_length = len(tokenizer(text, add_special_tokens=True)["input_ids"])
+            generated_tokens = max(0, current_length - initial_length)
+            remaining_tokens = max_new_tokens - generated_tokens
+            if remaining_tokens <= 0:
+                break
+
+            accepted_candidate = None
+            last_candidate = None
+            for _ in range(self.config.max_trials):
+                candidate = self._generate_candidate(text, remaining_tokens)
+                if not candidate:
+                    break
+                last_candidate = candidate
+                candidate_for_embedding = f" {candidate}"
+                if self.in_interval(
+                    self.similarity(previous_sentence, candidate_for_embedding)
+                ):
+                    accepted_candidate = candidate
+                    break
+
+            candidate = accepted_candidate or last_candidate
+            if not candidate:
+                break
+            text = f"{text.rstrip()} {candidate.lstrip()}"
+            previous_sentence = f" {candidate.lstrip()}"
+
+        return text
+
+
+class SimMark(BaseWatermark):
+    """Sentence-level similarity rejection-sampling watermark."""
+
+    def __init__(
+        self,
+        algorithm_config: str | SimMarkConfig,
+        transformers_config: TransformersConfig | None = None,
+        *args,
+        **kwargs,
+    ) -> None:
+        if isinstance(algorithm_config, str):
+            self.config = SimMarkConfig(algorithm_config, transformers_config, **kwargs)
+        elif isinstance(algorithm_config, SimMarkConfig):
+            self.config = algorithm_config
+        else:
+            raise TypeError(
+                "algorithm_config must be a path string or SimMarkConfig instance"
+            )
+        self.utils = SimMarkUtils(self.config)
+
+    def generate_watermarked_text(self, prompt: str, *args, **kwargs) -> str:
+        return self.utils.generate(prompt)
+
+    def detect_watermark(self, text: str, return_dict: bool = True, *args, **kwargs):
+        result = self.utils.score_text(text)
+        is_watermarked = bool(result.z_score > self.config.z_threshold)
+        if return_dict:
+            return {"is_watermarked": is_watermarked, "score": result.z_score}
+        return is_watermarked, result.z_score
+
+    def get_data_for_visualization(
+        self, text: str, *args, **kwargs
+    ) -> DataForVisualization:
+        sentences = split_sentences(text)
+        result = self.utils.score_text(text)
+        decoded_tokens = []
+        values = []
+        sentence_scores = [None, *result.soft_scores]
+        for sentence, score in zip(sentences, sentence_scores):
+            tokens = _VISUALIZATION_TOKEN.findall(sentence)
+            decoded_tokens.extend(tokens)
+            values.extend([score] * len(tokens))
+        return DataForVisualization(decoded_tokens, values)


### PR DESCRIPTION
## Summary

This PR integrates the cosine-similarity variant of [SimMark](https://github.com/DabiriAghdam/SimMark) (EMNLP 2025) into MarkLLM.

- add sentence-by-sentence rejection-sampling generation
- add soft-count z-score detection and continuous visualization
- add an explicit `config/SimMark.json` with the upstream C4/RealNews cosine defaults
- register SimMark with `AutoConfig` and `AutoWatermark`
- document upstream attribution, MIT license, and calibration requirements
- add focused tests for registration, scoring, generation, detection, and visualization

The cosine variant is used because it works with the public `hkunlp/instructor-large` embedder directly; the optional Euclidean variant requires a separate PCA checkpoint. `expected_valid_fraction` remains explicit because it should be recalibrated on human text when the domain, interval, or embedder changes.

## Validation

```text
uvx --from ruff==0.15.7 ruff check watermark/simmark test/test_simmark.py
All checks passed!

pytest -q test/test_simmark.py
4 passed
```

I also ran the MarkLLM detection pipelines end to end on CPU with `facebook/opt-125m`, `hkunlp/instructor-large`, and two C4 samples. For the short smoke run (`max_trials=10`):

```text
watermarked z-scores:       2.734,  2.767
natural-text z-scores:      1.302, -0.813
30% word-deletion scores:   2.667,  3.272
dynamic-threshold F1:       1.000
```

The checked-in default `max_trials=100` was also run without an override on one C4 sample and produced a z-score of `2.998` (default detection threshold: `2.33`). A real continuous visualization was generated successfully as part of the run.
